### PR TITLE
Add Construe clinician type-ahead coding demo

### DIFF
--- a/construe-typeahead/.env.example
+++ b/construe-typeahead/.env.example
@@ -1,0 +1,11 @@
+# PhenoML Construe credentials for Live mode.
+# Copy this file to `.env` and fill in your instance credentials.
+# These are read by Vite at dev/build time and seed the in-app Settings panel.
+#
+# WARNING: the client secret is sent from the browser in Live mode. This is for
+# internal/dev use only — do NOT paste production credentials, and do NOT ship a
+# build that bakes these into a public link.
+
+VITE_PHENOML_CLIENT_ID=
+VITE_PHENOML_CLIENT_SECRET=
+VITE_PHENOML_BASE_URL=https://experiment.app.pheno.ml

--- a/construe-typeahead/.gitignore
+++ b/construe-typeahead/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+.env.local
+*.local
+.DS_Store

--- a/construe-typeahead/README.md
+++ b/construe-typeahead/README.md
@@ -1,0 +1,145 @@
+# Construe Type-Ahead — Clinician Coding Demo
+
+A two-screen demo where a clinician types in **plain language** and the app silently
+stores **structured medical codes**. The UI shows human-readable text; the in-memory
+store holds the coded concepts. A **Show codes** toggle reveals exactly what was
+captured — the key sales moment.
+
+Powered by [PhenoML Construe](https://developer.pheno.ml) code search.
+
+![Plain language in · coded concepts out](#)
+
+## What it shows
+
+- **Encounter note** screen — a problem-list builder, a medication builder, and a
+  free-text clinical note.
+- **Orders** screen — an order-entry field.
+- Accepting a suggestion commits **display text** to the UI and **code(s)** to an
+  in-memory store. Flip **Show codes** to reveal the stored `system · code · description`
+  next to every committed entry.
+
+### Two search endpoints, by purpose
+
+| Field | Code system(s) | Endpoint | Why |
+| --- | --- | --- | --- |
+| Problem list | `SNOMED_CT_US_LITE` + `ICD-10-CM` | **text** | Fast prefix/substring type-ahead; stores **both** codes per problem |
+| Medication | `RXNORM` | **text** | Prefix/substring type-ahead |
+| Orders | `LOINC` | **text** | Prefix/substring type-ahead |
+| Clinical note | `SNOMED_CT_US_LITE` | **semantic** | The clinician writes a phrase, not a prefix — semantic finds the concept by meaning |
+
+### The ranking fix
+
+Construe text search is substring-based, so `asth` returns long co-occurrent descriptors
+(_"Acute exacerbation of asthma co-occurrent with allergic rhinitis"_) alongside the plain
+concept _"Asthma"_. The app re-ranks results client-side
+(`src/api/ranking.ts`) so exact-prefix and shortest-description matches float to the top
+and combination/co-occurrent concepts are demoted — the plain concept wins for a plain
+prefix.
+
+## Two modes
+
+- **Demo Mode (default ON)** — baked responses shaped exactly like a real Construe
+  `TextSearchResponse`. No credentials, fully standalone. Try `asth`, `albut`,
+  `shortness of breath` (note), `lipid panel`, `a1c`.
+- **Live Mode** — debounced (250 ms) calls to a real Construe instance using the
+  configured credentials. A single OAuth token is fetched once and reused across all
+  keystrokes (re-auth only on expiry or a 401).
+
+## Run it
+
+```bash
+npm install
+npm run dev      # opens http://localhost:5173
+```
+
+Other scripts:
+
+```bash
+npm run build      # tsc --noEmit + vite build
+npm run typecheck  # tsc --noEmit
+npm run preview    # preview the production build
+```
+
+## Live Mode credentials (`.env`)
+
+Copy `.env.example` to `.env` and fill in your instance credentials:
+
+```bash
+cp .env.example .env
+```
+
+```dotenv
+VITE_PHENOML_CLIENT_ID=your_client_id
+VITE_PHENOML_CLIENT_SECRET=your_client_secret
+VITE_PHENOML_BASE_URL=https://experiment.app.pheno.ml
+```
+
+These seed the in-app **Settings** panel (gear icon). You can also enter/override them
+there at runtime, and the **base URL is swappable** so you can point at any instance.
+
+> ⚠️ **Internal / dev use only.** In Live mode the client secret is sent from the
+> browser. Do **not** paste production credentials, and never share a public link that
+> bakes them in. For demos, leave Demo Mode on — it needs no credentials.
+
+### CORS caveat
+
+Live mode makes browser `fetch` calls directly to the Construe instance. If the instance
+does **not** return permissive CORS headers, the browser will block the call and Live
+mode will fail. **Demo Mode is the reliable default** and needs no network access. If you
+need Live mode locally against a CORS-restricted instance, proxy the requests (e.g. a
+small dev proxy or a server-side relay) so the browser sees a same-origin response.
+
+Handled gracefully in the UI: `401` (re-auth + retry once), `404` (code system not
+found), `501` (search not configured for that system), CORS/network failures, and empty
+results.
+
+## API contract
+
+```
+POST {baseUrl}/auth/token                 # OAuth2 client-credentials, creds in JSON body
+GET  {baseUrl}/construe/codes/{slug}/search/text?q={query}&limit=8
+GET  {baseUrl}/construe/codes/{slug}/search/semantic?q={query}&limit=8
+                                           # Authorization: Bearer <token>
+```
+
+Response shape (system name/version is on the parent `system` object, not per result):
+
+```json
+{ "system": { "name": "...", "version": "..." },
+  "results": [ { "code": "...", "description": "..." } ],
+  "found": 0 }
+```
+
+A stored coded concept is composed from `system.name` + `result.code` + `result.description`.
+
+## Architecture
+
+```
+src/
+  api/construe.ts     token cache + searchText/searchSemantic + error handling
+  api/ranking.ts      client-side re-ranking (pure, testable)
+  demo/fixtures.ts    baked TextSearchResponse data + semantic keyword map
+  hooks/useAppState   settings (env-seeded) + demo/show-codes + committed-code store
+  hooks/useTypeahead  debounced demo/live search; runs multi-system; applies ranking
+  components/         TopBar, SettingsPanel, RowBuilder, SuggestionList,
+                      NoteField + ChipRail, CommittedEntry, CodeBadge, Panel
+  screens/            EncounterScreen, OrdersScreen
+```
+
+### Settings shape (stable for a localStorage port)
+
+The Claude artifact sandbox blocks `localStorage`, so Settings is backed by React state.
+The signatures are kept identical so the app ports to a `localStorage` build unchanged —
+only the storage layer in `hooks/useAppState.tsx` would change:
+
+```ts
+export type Settings = { clientId: string; clientSecret: string; baseUrl: string };
+export const DEFAULT_SETTINGS: Settings = {
+  clientId: '', clientSecret: '', baseUrl: 'https://experiment.app.pheno.ml',
+};
+```
+
+## Stack
+
+Vite 7 · React 18 · TypeScript 5 · Mantine 8 (custom theme) · `@tabler/icons-react`.
+Same toolchain as the sibling `demochat/` demo.

--- a/construe-typeahead/index.html
+++ b/construe-typeahead/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Construe Type-Ahead — Clinician Coding Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/construe-typeahead/package-lock.json
+++ b/construe-typeahead/package-lock.json
@@ -1,0 +1,2239 @@
+{
+  "name": "construe-typeahead",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "construe-typeahead",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mantine/core": "^8.2.4",
+        "@mantine/hooks": "^8.2.4",
+        "@tabler/icons-react": "^3.34.1",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "@vitejs/plugin-react": "5.0.0",
+        "typescript": "^5.6.0",
+        "vite": "7.1.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mantine/core": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.18.tgz",
+      "integrity": "sha512-9tph1lTVogKPjTx02eUxDUOdXacPzK62UuSqb4TdGliI54/Xgxftq0Dfqu6XuhCxn9J5MDJaNiLDvL/1KRkYqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "clsx": "^2.1.1",
+        "react-number-format": "^5.4.4",
+        "react-remove-scroll": "^2.7.1",
+        "react-textarea-autosize": "8.5.9",
+        "type-fest": "^4.41.0"
+      },
+      "peerDependencies": {
+        "@mantine/hooks": "8.3.18",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/hooks": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.18.tgz",
+      "integrity": "sha512-QoWr9+S8gg5050TQ06aTSxtlpGjYOpIllRbjYYXlRvZeTsUqiTbVfvQROLexu4rEaK+yy9Wwriwl9PMRgbLqPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.30.tgz",
+      "integrity": "sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
+      "integrity": "sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.44.0.tgz",
+      "integrity": "sha512-8+rvzBbVm/1Z3sG3x7GUNAaxIKxwgz8xaMhRs23nrCnMTKRFAhEC+82zAIFeAA0seXdrAGX5HFCkaLpGK2rVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": "3.44.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.0.tgz",
+      "integrity": "sha512-Jx9JfsTa05bYkS9xo0hkofp2dCmp1blrKjw9JONs5BTHOvJCgLbaPSuZLGSVJW6u2qe0tc4eevY0+gSNNi0YCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.30",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.375",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-number-format": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.5.tgz",
+      "integrity": "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.1.tgz",
+      "integrity": "sha512-yJ+Mp7OyV+4S+afWo+QyoL9jFWD11QFH0i5i7JypnfTcA1rmgxCbiA8WwAICDEtZ1Z1hzrVhN8R8rGTqkTY8ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.6",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.14"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/construe-typeahead/package.json
+++ b/construe-typeahead/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "construe-typeahead",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Clinician type-ahead coding demo powered by PhenoML Construe",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mantine/core": "^8.2.4",
+    "@mantine/hooks": "^8.2.4",
+    "@tabler/icons-react": "^3.34.1",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "5.0.0",
+    "typescript": "^5.6.0",
+    "vite": "7.1.1"
+  }
+}

--- a/construe-typeahead/src/App.tsx
+++ b/construe-typeahead/src/App.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { Badge, Box, Group, Stack, Text } from '@mantine/core';
+import { IconBulb, IconEyeOff } from '@tabler/icons-react';
+import { useDisclosure } from '@mantine/hooks';
+import { TopBar, type Screen } from './components/TopBar';
+import { SettingsPanel } from './components/SettingsPanel';
+import { EncounterScreen } from './screens/EncounterScreen';
+import { OrdersScreen } from './screens/OrdersScreen';
+import { useAppState } from './hooks/useAppState';
+import { tokens } from './theme';
+
+export default function App() {
+  const [screen, setScreen] = useState<Screen>('encounter');
+  const [settingsOpened, settings] = useDisclosure(false);
+  const { demoMode, showCodes, entries } = useAppState();
+
+  return (
+    <Box>
+      <TopBar
+        screen={screen}
+        onChangeScreen={setScreen}
+        onOpenSettings={settings.open}
+      />
+
+      <Box
+        style={{
+          maxWidth: 1120,
+          margin: '0 auto',
+          padding: '28px 24px 96px',
+        }}
+      >
+        {/* Hero / framing line */}
+        <Stack gap={6} mb="lg">
+          <Group gap={10} align="center">
+            <Text
+              ff="Fraunces, serif"
+              fw={600}
+              style={{
+                fontSize: 30,
+                lineHeight: 1.1,
+                color: tokens.ink,
+                letterSpacing: '-0.01em',
+              }}
+            >
+              {screen === 'encounter' ? 'Encounter note' : 'Orders'}
+            </Text>
+            <Badge
+              variant="light"
+              color={demoMode ? 'teal' : 'coral'}
+              radius="sm"
+              size="lg"
+            >
+              {demoMode ? 'Demo Mode' : 'Live'}
+            </Badge>
+          </Group>
+          <Text size="sm" c="slate.7" maw={680}>
+            The clinician types in plain language; the app silently stores
+            structured medical codes. Toggle{' '}
+            <Text span fw={700} c="teal.8">
+              Show codes
+            </Text>{' '}
+            to reveal exactly what was captured.
+          </Text>
+        </Stack>
+
+        {/* Demo cheat-sheet */}
+        {demoMode && (
+          <Group
+            gap={10}
+            mb="lg"
+            p="sm"
+            wrap="wrap"
+            style={{
+              background: 'var(--mantine-color-teal-0)',
+              border: '1px solid var(--mantine-color-teal-2)',
+              borderRadius: 12,
+            }}
+          >
+            <Group gap={6}>
+              <IconBulb size={15} color="var(--mantine-color-teal-8)" />
+              <Text className="ct-eyebrow" c="teal.8">
+                Try
+              </Text>
+            </Group>
+            {(screen === 'encounter'
+              ? ['asth → Asthma', 'albut → Albuterol', 'shortness of breath (note)']
+              : ['lipid panel', 'a1c', 'creatinine']
+            ).map((t) => (
+              <Badge key={t} variant="white" color="teal" radius="sm" tt="none">
+                {t}
+              </Badge>
+            ))}
+          </Group>
+        )}
+
+        {/* Active screen */}
+        {screen === 'encounter' ? <EncounterScreen /> : <OrdersScreen />}
+
+        {/* Footer status */}
+        <Group gap={8} mt="xl" justify="center">
+          {!showCodes && entries.length > 0 && (
+            <Group gap={6}>
+              <IconEyeOff size={14} color="var(--mantine-color-slate-6)" />
+              <Text size="xs" c="slate.6">
+                {entries.length} coded {entries.length === 1 ? 'concept' : 'concepts'} stored
+                silently — flip “Show codes” to reveal them.
+              </Text>
+            </Group>
+          )}
+        </Group>
+      </Box>
+
+      <SettingsPanel opened={settingsOpened} onClose={settings.close} />
+    </Box>
+  );
+}

--- a/construe-typeahead/src/api/construe.ts
+++ b/construe-typeahead/src/api/construe.ts
@@ -1,0 +1,232 @@
+import {
+  SearchError,
+  type CodeSystemSlug,
+  type Settings,
+  type TextSearchResponse,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Construe API client.
+//
+// Auth: POST {baseUrl}/auth/token (OAuth2 client-credentials, creds in JSON
+// body). Token is fetched ONCE and cached with its expiry, reused across every
+// keystroke, and only re-minted on expiry or a 401. We never mint per stroke.
+//
+// Search: GET {baseUrl}/construe/codes/{slug}/search/{text|semantic}?q=&limit=
+// with a Bearer token.
+// ---------------------------------------------------------------------------
+
+interface CachedToken {
+  token: string;
+  expiresAt: number; // epoch ms
+  // The credentials this token was minted for — if any change, re-auth.
+  baseUrl: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+let cachedToken: CachedToken | null = null;
+
+// Refresh slightly before the real expiry to avoid edge-of-expiry 401s.
+const EXPIRY_SKEW_MS = 30_000;
+
+function credsMatch(c: CachedToken, s: Settings): boolean {
+  return (
+    c.baseUrl === s.baseUrl &&
+    c.clientId === s.clientId &&
+    c.clientSecret === s.clientSecret
+  );
+}
+
+/** Clear the cached token (call this on a 401 before retrying). */
+export function clearToken(): void {
+  cachedToken = null;
+}
+
+function trimBase(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+/**
+ * Fetch a fresh OAuth token. Parses the standard OAuth client-credentials
+ * shape (access_token / expires_in) with token / expiry fallbacks, since the
+ * exact field names aren't pinned in-repo yet.
+ */
+async function fetchToken(settings: Settings): Promise<CachedToken> {
+  const url = `${trimBase(settings.baseUrl)}/auth/token`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: settings.clientId,
+        client_secret: settings.clientSecret,
+      }),
+    });
+  } catch (e) {
+    throw new SearchError(
+      'network',
+      `Could not reach ${url}. If this is a browser CORS block, use Demo Mode. (${
+        e instanceof Error ? e.message : String(e)
+      })`,
+    );
+  }
+
+  if (resp.status === 401 || resp.status === 403) {
+    throw new SearchError(
+      'auth',
+      'Authentication failed — check the client ID and secret in Settings.',
+      resp.status,
+    );
+  }
+  if (!resp.ok) {
+    throw new SearchError(
+      'unknown',
+      `Auth request failed (HTTP ${resp.status}).`,
+      resp.status,
+    );
+  }
+
+  const data: Record<string, unknown> = await resp.json().catch(() => ({}));
+  const token = (data.access_token ?? data.token) as string | undefined;
+  if (!token) {
+    throw new SearchError('auth', 'Auth response did not include a token.');
+  }
+
+  // Compute expiry. Prefer expires_in (seconds); fall back to an absolute
+  // expiry field, else default to 1 hour.
+  const expiresIn = data.expires_in as number | undefined;
+  const absExpiry = data.expiry as number | string | undefined;
+  let expiresAt: number;
+  if (typeof expiresIn === 'number') {
+    expiresAt = nowMs() + expiresIn * 1000;
+  } else if (typeof absExpiry === 'number') {
+    expiresAt = absExpiry > 1e12 ? absExpiry : absExpiry * 1000;
+  } else if (typeof absExpiry === 'string') {
+    const parsed = Date.parse(absExpiry);
+    expiresAt = Number.isNaN(parsed) ? nowMs() + 3_600_000 : parsed;
+  } else {
+    expiresAt = nowMs() + 3_600_000;
+  }
+
+  return {
+    token,
+    expiresAt,
+    baseUrl: settings.baseUrl,
+    clientId: settings.clientId,
+    clientSecret: settings.clientSecret,
+  };
+}
+
+function nowMs(): number {
+  return new Date().getTime();
+}
+
+/** Get a valid token from cache, or mint a new one. */
+async function getToken(settings: Settings): Promise<string> {
+  if (
+    cachedToken &&
+    credsMatch(cachedToken, settings) &&
+    cachedToken.expiresAt - EXPIRY_SKEW_MS > nowMs()
+  ) {
+    return cachedToken.token;
+  }
+  cachedToken = await fetchToken(settings);
+  return cachedToken.token;
+}
+
+type SearchMode = 'text' | 'semantic';
+
+async function doSearch(
+  settings: Settings,
+  slug: CodeSystemSlug,
+  mode: SearchMode,
+  query: string,
+  token: string,
+  limit: number,
+): Promise<Response> {
+  const url =
+    `${trimBase(settings.baseUrl)}/construe/codes/${slug}/search/${mode}` +
+    `?q=${encodeURIComponent(query)}&limit=${limit}`;
+  try {
+    return await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch (e) {
+    throw new SearchError(
+      'network',
+      `Could not reach Construe. If this is a browser CORS block, use Demo Mode. (${
+        e instanceof Error ? e.message : String(e)
+      })`,
+    );
+  }
+}
+
+/**
+ * Run a Construe search (text or semantic). Handles token caching, a single
+ * re-auth + retry on 401, and maps 404/501/other statuses to SearchError.
+ */
+async function search(
+  settings: Settings,
+  slug: CodeSystemSlug,
+  mode: SearchMode,
+  query: string,
+  limit = 8,
+): Promise<TextSearchResponse> {
+  let token = await getToken(settings);
+  let resp = await doSearch(settings, slug, mode, query, token, limit);
+
+  // 401 → token may have expired server-side. Re-auth once and retry.
+  if (resp.status === 401) {
+    clearToken();
+    token = await getToken(settings);
+    resp = await doSearch(settings, slug, mode, query, token, limit);
+  }
+
+  if (resp.status === 401) {
+    throw new SearchError('auth', 'Unauthorized — re-auth failed.', 401);
+  }
+  if (resp.status === 404) {
+    throw new SearchError(
+      'not_found',
+      `Code system "${slug}" not found on this instance.`,
+      404,
+    );
+  }
+  if (resp.status === 501) {
+    throw new SearchError(
+      'not_configured',
+      `${mode === 'text' ? 'Text' : 'Semantic'} search is not configured for "${slug}" on this instance.`,
+      501,
+    );
+  }
+  if (!resp.ok) {
+    throw new SearchError('unknown', `Search failed (HTTP ${resp.status}).`, resp.status);
+  }
+
+  const data = (await resp.json().catch(() => null)) as TextSearchResponse | null;
+  if (!data || !Array.isArray(data.results)) {
+    throw new SearchError('unknown', 'Unexpected response shape from Construe.');
+  }
+  return data;
+}
+
+export function searchText(
+  settings: Settings,
+  slug: CodeSystemSlug,
+  query: string,
+  limit = 8,
+): Promise<TextSearchResponse> {
+  return search(settings, slug, 'text', query, limit);
+}
+
+export function searchSemantic(
+  settings: Settings,
+  slug: CodeSystemSlug,
+  query: string,
+  limit = 8,
+): Promise<TextSearchResponse> {
+  return search(settings, slug, 'semantic', query, limit);
+}

--- a/construe-typeahead/src/api/ranking.ts
+++ b/construe-typeahead/src/api/ranking.ts
@@ -1,0 +1,90 @@
+import type { SearchResultItem } from '../types';
+
+// ---------------------------------------------------------------------------
+// Client-side re-ranking.
+//
+// Construe text search is substring-based, so a query like "asth" returns long
+// co-occurrent descriptors ("Acute exacerbation of asthma co-occurrent with
+// allergic rhinitis") alongside the plain concept "Asthma". For a plain prefix
+// the plain concept should win. We re-rank so that:
+//   1. exact-prefix matches float to the top,
+//   2. shorter descriptions beat longer ones,
+//   3. combination / co-occurrent concepts are demoted.
+// ---------------------------------------------------------------------------
+
+// Tokens that signal a combination / co-occurrent / qualified concept. Their
+// presence pushes a result down so the plain concept surfaces first.
+const COMBINATION_MARKERS = [
+  'co-occurrent',
+  'cooccurrent',
+  ' with ',
+  ' due to ',
+  ' associated with ',
+  ' and ',
+  ' in ',
+  ' without ',
+  ' complicating ',
+  ' secondary to ',
+];
+
+function norm(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+/**
+ * Score a single result against the query. Higher is better.
+ * Pure function of (query, item) so it is trivially testable.
+ */
+export function scoreResult(query: string, item: SearchResultItem): number {
+  const q = norm(query);
+  const desc = norm(item.description);
+  if (!q) return 0;
+
+  let score = 0;
+
+  // Exact match of the whole description — the strongest signal.
+  if (desc === q) score += 1000;
+
+  // Prefix match: the description starts with the typed query.
+  if (desc.startsWith(q)) score += 500;
+  // Whole-word match somewhere (e.g. query "asthma" inside the description).
+  else if (new RegExp(`\\b${escapeRegExp(q)}\\b`).test(desc)) score += 200;
+  // Plain substring (the default Construe behaviour) — weakest positive.
+  else if (desc.includes(q)) score += 80;
+
+  // Demote combination / co-occurrent concepts.
+  for (const marker of COMBINATION_MARKERS) {
+    if (desc.includes(marker.trim()) && desc.includes(marker)) {
+      score -= 120;
+      break;
+    }
+  }
+
+  // Prefer shorter, plainer descriptions. Subtract a gentle length penalty so
+  // "Asthma" (6 chars) beats a 60-char co-occurrent descriptor on a tie.
+  score -= desc.length * 0.8;
+
+  // A description with a comma or parenthetical qualifier is usually more
+  // specific/longer than the plain concept — small extra demotion.
+  if (desc.includes(',') || desc.includes('(')) score -= 15;
+
+  return score;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Re-rank Construe results client-side for a plain-prefix type-ahead. Stable
+ * for equal scores (preserves the server order as a tiebreaker).
+ */
+export function rankResults(
+  query: string,
+  results: SearchResultItem[],
+): SearchResultItem[] {
+  return results
+    .map((item, index) => ({ item, index, score: scoreResult(query, item) }))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((r) => r.item);
+}

--- a/construe-typeahead/src/components/ChipRail.tsx
+++ b/construe-typeahead/src/components/ChipRail.tsx
@@ -1,0 +1,115 @@
+import { Box, Group, Loader, Text } from '@mantine/core';
+import { IconPlus, IconSparkles } from '@tabler/icons-react';
+import type { SearchErrorKind, Suggestion } from '../types';
+
+interface ChipRailProps {
+  suggestions: Suggestion[];
+  loading: boolean;
+  error: { kind: SearchErrorKind; message: string } | null;
+  hasQuery: boolean;
+  showCodes: boolean;
+  onTap: (s: Suggestion) => void;
+}
+
+// The note field's semantic rail: tappable SNOMED concept chips surfaced by
+// meaning as the clinician writes. Tapping a chip commits a coded tag.
+export function ChipRail({
+  suggestions,
+  loading,
+  error,
+  hasQuery,
+  showCodes,
+  onTap,
+}: ChipRailProps) {
+  if (!hasQuery) return null;
+
+  if (error) {
+    return (
+      <Text size="xs" c="coral.7" mt={8}>
+        {error.message}
+      </Text>
+    );
+  }
+
+  if (loading && suggestions.length === 0) {
+    return (
+      <Group gap={8} mt={10}>
+        <Loader size="xs" color="teal" />
+        <Text size="xs" c="slate.6">
+          Reading the note semantically…
+        </Text>
+      </Group>
+    );
+  }
+
+  if (suggestions.length === 0) return null;
+
+  return (
+    <Box mt={10}>
+      <Group gap={6} mb={6} align="center">
+        <IconSparkles size={13} color="var(--mantine-color-teal-7)" />
+        <Text className="ct-eyebrow" c="teal.8" style={{ letterSpacing: '0.12em' }}>
+          Suggested concepts
+        </Text>
+      </Group>
+      <Group gap={8}>
+        {suggestions.map((s, i) => {
+          const code = s.codes[0]?.code;
+          return (
+            <Box
+              key={s.id}
+              className="ct-chip-in"
+              role="button"
+              tabIndex={0}
+              onClick={() => onTap(s)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onTap(s);
+                }
+              }}
+              style={{
+                animationDelay: `${i * 40}ms`,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                cursor: 'pointer',
+                padding: '6px 10px 6px 8px',
+                borderRadius: 999,
+                border: '1px solid var(--mantine-color-teal-2)',
+                background: 'var(--mantine-color-teal-0)',
+                transition: 'transform 120ms ease, box-shadow 120ms ease',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.transform = 'translateY(-1px)';
+                e.currentTarget.style.boxShadow = 'var(--mantine-shadow-sm)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = 'translateY(0)';
+                e.currentTarget.style.boxShadow = 'none';
+              }}
+            >
+              <IconPlus size={13} color="var(--mantine-color-teal-7)" />
+              <Text size="sm" fw={600} c="teal.9">
+                {s.label}
+              </Text>
+              {showCodes && code && (
+                <Text
+                  span
+                  style={{
+                    fontFamily: 'var(--mantine-font-family-monospace)',
+                    fontSize: 11,
+                    fontWeight: 700,
+                    color: 'var(--mantine-color-teal-7)',
+                  }}
+                >
+                  {code}
+                </Text>
+              )}
+            </Box>
+          );
+        })}
+      </Group>
+    </Box>
+  );
+}

--- a/construe-typeahead/src/components/CodeBadge.tsx
+++ b/construe-typeahead/src/components/CodeBadge.tsx
@@ -1,0 +1,57 @@
+import { Box, Group, Text } from '@mantine/core';
+import type { CodedConcept } from '../types';
+import { tokens } from '../theme';
+
+// A single stored coded concept, rendered with a deliberately "machine"
+// treatment (dark slab + mono code) so structured data reads visually distinct
+// from the human-readable text above it.
+export function CodeBadge({ concept }: { concept: CodedConcept }) {
+  return (
+    <Box
+      style={{
+        background: tokens.codeBg,
+        borderRadius: 10,
+        padding: '6px 10px',
+        border: '1px solid rgba(127, 232, 210, 0.18)',
+      }}
+    >
+      <Group gap={8} wrap="nowrap" align="center">
+        <Text
+          span
+          style={{
+            fontFamily: 'var(--mantine-font-family-monospace)',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.04em',
+            color: 'rgba(255,255,255,0.55)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {concept.system}
+        </Text>
+        <Text
+          span
+          style={{
+            fontFamily: 'var(--mantine-font-family-monospace)',
+            fontSize: 13,
+            fontWeight: 700,
+            color: tokens.codeInk,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {concept.code}
+        </Text>
+        <Text
+          span
+          style={{
+            fontSize: 12.5,
+            color: 'rgba(255,255,255,0.82)',
+            lineHeight: 1.3,
+          }}
+        >
+          {concept.description}
+        </Text>
+      </Group>
+    </Box>
+  );
+}

--- a/construe-typeahead/src/components/CommittedEntry.tsx
+++ b/construe-typeahead/src/components/CommittedEntry.tsx
@@ -1,0 +1,58 @@
+import { ActionIcon, Box, Group, Stack, Text } from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
+import type { CommittedEntry as Entry } from '../types';
+import { useAppState } from '../hooks/useAppState';
+import { CodeBadge } from './CodeBadge';
+import { tokens } from '../theme';
+
+// One committed item: the human-readable text the clinician sees, plus the
+// stored codes revealed when "Show codes" is on (the key sales moment).
+export function CommittedEntry({ entry }: { entry: Entry }) {
+  const { showCodes, removeEntry } = useAppState();
+
+  return (
+    <Box
+      style={{
+        background: tokens.surface,
+        border: `1px solid ${tokens.border}`,
+        borderRadius: 14,
+        padding: '12px 14px',
+        boxShadow: 'var(--mantine-shadow-xs)',
+      }}
+    >
+      <Group justify="space-between" wrap="nowrap" align="flex-start">
+        <Group gap={10} wrap="nowrap" align="center" style={{ flex: 1, minWidth: 0 }}>
+          <Box
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: 8,
+              background: 'var(--mantine-color-teal-6)',
+              flexShrink: 0,
+            }}
+          />
+          <Text fw={600} size="sm" style={{ color: tokens.ink }}>
+            {entry.text}
+          </Text>
+        </Group>
+        <ActionIcon
+          variant="subtle"
+          color="slate"
+          size="sm"
+          aria-label="Remove"
+          onClick={() => removeEntry(entry.id)}
+        >
+          <IconX size={15} />
+        </ActionIcon>
+      </Group>
+
+      {showCodes && entry.codes.length > 0 && (
+        <Stack gap={6} mt={10} className="ct-flip-in">
+          {entry.codes.map((c) => (
+            <CodeBadge key={`${c.system}:${c.code}`} concept={c} />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/construe-typeahead/src/components/NoteField.tsx
+++ b/construe-typeahead/src/components/NoteField.tsx
@@ -1,0 +1,124 @@
+import { Box, Group, Stack, Text, Textarea } from '@mantine/core';
+import { IconX } from '@tabler/icons-react';
+import { useTypeahead } from '../hooks/useTypeahead';
+import { useAppState } from '../hooks/useAppState';
+import { ChipRail } from './ChipRail';
+import type { CodeSystemSlug, Suggestion } from '../types';
+import { tokens } from '../theme';
+
+// Free-text note → SNOMED via SEMANTIC search (the clinician writes a phrase,
+// not a prefix). Suggested concept chips appear beneath the field; tapping one
+// commits a coded tag. Committed tags show their code when "Show codes" is on.
+const NOTE_SYSTEMS: CodeSystemSlug[] = ['SNOMED_CT_US_LITE'];
+
+export function NoteField() {
+  const { commit, showCodes, entriesByKind, removeEntry } = useAppState();
+  const { query, setQuery, suggestions, loading, error } = useTypeahead({
+    systems: NOTE_SYSTEMS,
+    mode: 'semantic',
+    minLength: 3,
+  });
+
+  const tags = entriesByKind('note');
+  const committedCodes = new Set(tags.map((t) => t.codes[0]?.code));
+
+  function accept(s: Suggestion) {
+    if (committedCodes.has(s.codes[0]?.code)) return; // avoid duplicate tags
+    commit('note', s.label, s.codes);
+  }
+
+  return (
+    <Box>
+      <Text className="ct-eyebrow" c="slate.7" mb={4}>
+        Clinical note
+      </Text>
+      <Text size="xs" c="slate.6" mb={8}>
+        Write freely — semantic search finds SNOMED concepts by meaning, not spelling.
+      </Text>
+
+      <Textarea
+        value={query}
+        onChange={(e) => setQuery(e.currentTarget.value)}
+        placeholder="e.g. Patient reports shortness of breath on exertion and a dry cough."
+        autosize
+        minRows={3}
+        radius="md"
+        styles={{
+          input: {
+            borderColor: tokens.border,
+            backgroundColor: tokens.surface,
+            lineHeight: 1.55,
+          },
+        }}
+      />
+
+      <ChipRail
+        suggestions={suggestions}
+        loading={loading}
+        error={error}
+        hasQuery={query.trim().length >= 3}
+        showCodes={showCodes}
+        onTap={accept}
+      />
+
+      {tags.length > 0 && (
+        <Stack gap={6} mt={14}>
+          <Text className="ct-eyebrow" c="slate.7">
+            Coded tags
+          </Text>
+          <Group gap={8}>
+            {tags.map((tag) => {
+              const code = tag.codes[0];
+              return (
+                <Group
+                  key={tag.id}
+                  gap={8}
+                  wrap="nowrap"
+                  style={{
+                    padding: '5px 6px 5px 12px',
+                    borderRadius: 999,
+                    background: 'var(--mantine-color-teal-7)',
+                  }}
+                >
+                  <Text size="sm" fw={600} c="white">
+                    {tag.text}
+                  </Text>
+                  {showCodes && code && (
+                    <Text
+                      span
+                      className="ct-flip-in"
+                      style={{
+                        fontFamily: 'var(--mantine-font-family-monospace)',
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: tokens.codeInk,
+                        background: 'rgba(0,0,0,0.28)',
+                        borderRadius: 7,
+                        padding: '2px 7px',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {code.code}
+                    </Text>
+                  )}
+                  <Box
+                    role="button"
+                    aria-label="Remove tag"
+                    onClick={() => removeEntry(tag.id)}
+                    style={{
+                      display: 'inline-flex',
+                      cursor: 'pointer',
+                      color: 'rgba(255,255,255,0.8)',
+                    }}
+                  >
+                    <IconX size={14} />
+                  </Box>
+                </Group>
+              );
+            })}
+          </Group>
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/construe-typeahead/src/components/Panel.tsx
+++ b/construe-typeahead/src/components/Panel.tsx
@@ -1,0 +1,46 @@
+import { Box, Group, Text } from '@mantine/core';
+import type { ReactNode } from 'react';
+import { tokens } from '../theme';
+
+// A "clinical chart" card used to group each field on a screen.
+export function Panel({
+  title,
+  accent,
+  children,
+}: {
+  title: string;
+  accent?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <Box
+      style={{
+        background: tokens.surface,
+        border: `1px solid ${tokens.border}`,
+        borderRadius: 20,
+        boxShadow: 'var(--mantine-shadow-sm)',
+        // NOTE: no `overflow: hidden` here — it would clip the type-ahead
+        // dropdown (positioned just below the input) whenever the panel is
+        // short. The header rounds its own top corners instead.
+      }}
+    >
+      <Group
+        justify="space-between"
+        px="lg"
+        py="sm"
+        style={{
+          borderBottom: `1px solid ${tokens.canvas}`,
+          background: 'linear-gradient(180deg, #fbfdfe, #f4f8fa)',
+          borderTopLeftRadius: 20,
+          borderTopRightRadius: 20,
+        }}
+      >
+        <Text fw={700} ff="Fraunces, serif" fz="md" style={{ color: tokens.ink }}>
+          {title}
+        </Text>
+        {accent}
+      </Group>
+      <Box p="lg">{children}</Box>
+    </Box>
+  );
+}

--- a/construe-typeahead/src/components/RowBuilder.tsx
+++ b/construe-typeahead/src/components/RowBuilder.tsx
@@ -1,0 +1,128 @@
+import { useRef, useState } from 'react';
+import { Box, Stack, Text, TextInput } from '@mantine/core';
+import { IconPlus } from '@tabler/icons-react';
+import { useTypeahead, type SearchMode } from '../hooks/useTypeahead';
+import { useAppState } from '../hooks/useAppState';
+import { CommittedEntry } from './CommittedEntry';
+import { SuggestionList } from './SuggestionList';
+import type { CodeSystemSlug, FieldKind, Suggestion } from '../types';
+import { tokens } from '../theme';
+
+interface RowBuilderProps {
+  kind: FieldKind;
+  systems: CodeSystemSlug[];
+  mode?: SearchMode;
+  label: string;
+  hint: string;
+  placeholder: string;
+  minLength?: number;
+}
+
+// Generic "type a phrase → pick a ranked suggestion → commit display text +
+// code(s)" builder. Shared by problem list, medication, and orders fields.
+export function RowBuilder({
+  kind,
+  systems,
+  mode = 'text',
+  label,
+  hint,
+  placeholder,
+  minLength = 2,
+}: RowBuilderProps) {
+  const { commit, showCodes, entriesByKind } = useAppState();
+  const { query, setQuery, suggestions, loading, error, reset } = useTypeahead({
+    systems,
+    mode,
+    minLength,
+  });
+  const [focused, setFocused] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const entries = entriesByKind(kind);
+  const open = focused && query.trim().length >= minLength;
+
+  function accept(s: Suggestion) {
+    commit(kind, s.label, s.codes);
+    reset();
+    setActiveIndex(0);
+    inputRef.current?.focus();
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open || suggestions.length === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % suggestions.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + suggestions.length) % suggestions.length);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const choice = suggestions[Math.min(activeIndex, suggestions.length - 1)];
+      if (choice) accept(choice);
+    } else if (e.key === 'Escape') {
+      reset();
+    }
+  }
+
+  // Clamp the highlight in case the result set shrank since the last keystroke.
+  const clampedActive =
+    suggestions.length > 0 ? Math.min(activeIndex, suggestions.length - 1) : 0;
+
+  return (
+    <Box>
+      <Text className="ct-eyebrow" c="slate.7" mb={4}>
+        {label}
+      </Text>
+      <Text size="xs" c="slate.6" mb={8}>
+        {hint}
+      </Text>
+
+      <Box style={{ position: 'relative' }}>
+        <TextInput
+          ref={inputRef}
+          value={query}
+          placeholder={placeholder}
+          leftSection={<IconPlus size={16} />}
+          onChange={(e) => {
+            setQuery(e.currentTarget.value);
+            setActiveIndex(0);
+          }}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          onKeyDown={onKeyDown}
+          size="md"
+          radius="md"
+          styles={{
+            input: {
+              borderColor: tokens.border,
+              backgroundColor: tokens.surface,
+              fontWeight: 500,
+            },
+          }}
+        />
+        {open && (
+          <SuggestionList
+            suggestions={suggestions}
+            activeIndex={clampedActive}
+            loading={loading}
+            error={error}
+            query={query}
+            showCodes={showCodes}
+            onHover={setActiveIndex}
+            onSelect={accept}
+          />
+        )}
+      </Box>
+
+      {entries.length > 0 && (
+        <Stack gap={8} mt={12}>
+          {entries.map((entry) => (
+            <CommittedEntry key={entry.id} entry={entry} />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/construe-typeahead/src/components/SettingsPanel.tsx
+++ b/construe-typeahead/src/components/SettingsPanel.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Group,
+  Modal,
+  PasswordInput,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { IconShieldLock } from '@tabler/icons-react';
+import { useAppState } from '../hooks/useAppState';
+import type { Settings } from '../types';
+
+// Collects clientId / clientSecret / baseUrl. baseUrl is editable so the
+// instance host can be swapped (we run multiple instances). Values are seeded
+// from .env when present. Includes the mandatory browser-secret warning.
+export function SettingsPanel({
+  opened,
+  onClose,
+}: {
+  opened: boolean;
+  onClose: () => void;
+}) {
+  const { settings, updateSettings } = useAppState();
+  const [form, setForm] = useState<Settings>(settings);
+
+  // Re-sync the form whenever the panel reopens.
+  useEffect(() => {
+    if (opened) setForm(settings);
+  }, [opened, settings]);
+
+  function save() {
+    updateSettings({
+      clientId: form.clientId.trim(),
+      clientSecret: form.clientSecret.trim(),
+      baseUrl: form.baseUrl.trim() || settings.baseUrl,
+    });
+    onClose();
+  }
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={
+        <Text fw={700} ff="Fraunces, serif" fz="lg">
+          Construe connection
+        </Text>
+      }
+      radius="lg"
+      size="lg"
+      centered
+    >
+      <Stack gap="md">
+        <Alert
+          variant="light"
+          color="coral"
+          icon={<IconShieldLock size={18} />}
+          radius="md"
+        >
+          <Text size="sm" fw={600} mb={2}>
+            Internal / dev use only
+          </Text>
+          <Text size="xs">
+            In Live mode the client secret is sent straight from the browser. Do
+            not paste production credentials, and never share a public link that
+            bakes these in. For demos, leave Demo Mode on — it needs no creds.
+          </Text>
+        </Alert>
+
+        <TextInput
+          label="Instance base URL"
+          description="Swap this to point at a different Construe instance."
+          value={form.baseUrl}
+          onChange={(e) => setForm({ ...form, baseUrl: e.currentTarget.value })}
+          placeholder="https://experiment.app.pheno.ml"
+          radius="md"
+        />
+        <TextInput
+          label="Client ID"
+          value={form.clientId}
+          onChange={(e) => setForm({ ...form, clientId: e.currentTarget.value })}
+          placeholder="client_id"
+          radius="md"
+        />
+        <PasswordInput
+          label="Client secret"
+          value={form.clientSecret}
+          onChange={(e) => setForm({ ...form, clientSecret: e.currentTarget.value })}
+          placeholder="client_secret"
+          radius="md"
+        />
+
+        <Text size="xs" c="slate.6">
+          Tip: set <code>VITE_PHENOML_CLIENT_ID</code>,{' '}
+          <code>VITE_PHENOML_CLIENT_SECRET</code> and{' '}
+          <code>VITE_PHENOML_BASE_URL</code> in a <code>.env</code> file to
+          pre-fill these.
+        </Text>
+
+        <Group justify="flex-end" mt={4}>
+          <Button variant="subtle" color="slate" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button color="teal" onClick={save}>
+            Save connection
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/construe-typeahead/src/components/SuggestionList.tsx
+++ b/construe-typeahead/src/components/SuggestionList.tsx
@@ -1,0 +1,157 @@
+import { Box, Group, Loader, Text } from '@mantine/core';
+import { IconAlertTriangle, IconSearch } from '@tabler/icons-react';
+import type { SearchErrorKind, Suggestion } from '../types';
+import { tokens } from '../theme';
+
+interface SuggestionListProps {
+  suggestions: Suggestion[];
+  activeIndex: number;
+  loading: boolean;
+  error: { kind: SearchErrorKind; message: string } | null;
+  query: string;
+  showCodes: boolean;
+  onHover: (index: number) => void;
+  onSelect: (s: Suggestion) => void;
+}
+
+const panelStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 'calc(100% + 8px)',
+  left: 0,
+  right: 0,
+  zIndex: 40,
+  background: tokens.surface,
+  border: `1px solid ${tokens.border}`,
+  borderRadius: 14,
+  boxShadow: 'var(--mantine-shadow-lg)',
+  overflow: 'hidden',
+};
+
+export function SuggestionList({
+  suggestions,
+  activeIndex,
+  loading,
+  error,
+  query,
+  showCodes,
+  onHover,
+  onSelect,
+}: SuggestionListProps) {
+  if (query.trim().length < 2) return null;
+
+  if (error) {
+    return (
+      <Box style={panelStyle} className="ct-pop-in">
+        <Group gap={10} p="md" wrap="nowrap" align="flex-start">
+          <IconAlertTriangle size={18} color="var(--mantine-color-coral-6)" />
+          <Box>
+            <Text size="sm" fw={600} c="coral.8">
+              {errorTitle(error.kind)}
+            </Text>
+            <Text size="xs" c="slate.7" mt={2}>
+              {error.message}
+            </Text>
+          </Box>
+        </Group>
+      </Box>
+    );
+  }
+
+  if (loading && suggestions.length === 0) {
+    return (
+      <Box style={panelStyle} className="ct-pop-in">
+        <Group gap={10} p="md">
+          <Loader size="xs" color="teal" />
+          <Text size="sm" c="slate.7">
+            Searching Construe…
+          </Text>
+        </Group>
+      </Box>
+    );
+  }
+
+  if (suggestions.length === 0) {
+    return (
+      <Box style={panelStyle} className="ct-pop-in">
+        <Group gap={10} p="md">
+          <IconSearch size={16} color="var(--mantine-color-slate-5)" />
+          <Text size="sm" c="slate.7">
+            No matching concepts for “{query.trim()}”.
+          </Text>
+        </Group>
+      </Box>
+    );
+  }
+
+  return (
+    <Box style={panelStyle} className="ct-pop-in" role="listbox">
+      {suggestions.map((s, i) => {
+        const active = i === activeIndex;
+        const primary = s.codes[0];
+        return (
+          <Group
+            key={s.id}
+            role="option"
+            aria-selected={active}
+            justify="space-between"
+            wrap="nowrap"
+            gap={12}
+            px="md"
+            py={10}
+            onMouseEnter={() => onHover(i)}
+            onMouseDown={(e) => {
+              // mousedown (not click) so we commit before the input blurs.
+              e.preventDefault();
+              onSelect(s);
+            }}
+            style={{
+              cursor: 'pointer',
+              background: active ? 'var(--mantine-color-teal-0)' : 'transparent',
+              borderLeft: `3px solid ${
+                active ? 'var(--mantine-color-teal-6)' : 'transparent'
+              }`,
+              borderBottom: i === suggestions.length - 1 ? 'none' : `1px solid ${tokens.canvas}`,
+            }}
+          >
+            <Text size="sm" fw={active ? 600 : 500} style={{ color: tokens.ink }}>
+              {s.label}
+            </Text>
+            {showCodes && primary && (
+              <Text
+                span
+                style={{
+                  fontFamily: 'var(--mantine-font-family-monospace)',
+                  fontSize: 11.5,
+                  fontWeight: 700,
+                  color: 'var(--mantine-color-teal-8)',
+                  background: 'var(--mantine-color-teal-0)',
+                  border: '1px solid var(--mantine-color-teal-2)',
+                  borderRadius: 7,
+                  padding: '2px 7px',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {primary.code}
+              </Text>
+            )}
+          </Group>
+        );
+      })}
+    </Box>
+  );
+}
+
+function errorTitle(kind: SearchErrorKind): string {
+  switch (kind) {
+    case 'auth':
+      return 'Authentication failed';
+    case 'not_found':
+      return 'Code system not found';
+    case 'not_configured':
+      return 'Search not configured';
+    case 'network':
+      return 'Could not reach Construe';
+    default:
+      return 'Search error';
+  }
+}

--- a/construe-typeahead/src/components/TopBar.tsx
+++ b/construe-typeahead/src/components/TopBar.tsx
@@ -1,0 +1,149 @@
+import {
+  ActionIcon,
+  Badge,
+  Box,
+  Group,
+  SegmentedControl,
+  Switch,
+  Text,
+  Tooltip,
+} from '@mantine/core';
+import { IconCode, IconSettings, IconStethoscope } from '@tabler/icons-react';
+import { useAppState } from '../hooks/useAppState';
+import { tokens } from '../theme';
+
+export type Screen = 'encounter' | 'orders';
+
+export function TopBar({
+  screen,
+  onChangeScreen,
+  onOpenSettings,
+}: {
+  screen: Screen;
+  onChangeScreen: (s: Screen) => void;
+  onOpenSettings: () => void;
+}) {
+  const { demoMode, setDemoMode, showCodes, setShowCodes, settings } = useAppState();
+  const liveReady = Boolean(settings.clientId && settings.clientSecret);
+
+  return (
+    <Box
+      style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 50,
+        background: 'rgba(255,255,255,0.82)',
+        backdropFilter: 'blur(12px)',
+        borderBottom: `1px solid ${tokens.border}`,
+      }}
+    >
+      <Group
+        justify="space-between"
+        wrap="nowrap"
+        px="xl"
+        py="sm"
+        style={{ maxWidth: 1120, margin: '0 auto' }}
+      >
+        {/* Brand */}
+        <Group gap={12} wrap="nowrap">
+          <Box
+            style={{
+              width: 38,
+              height: 38,
+              borderRadius: 12,
+              background: 'linear-gradient(135deg, var(--mantine-color-teal-6), var(--mantine-color-teal-9))',
+              display: 'grid',
+              placeItems: 'center',
+              boxShadow: 'var(--mantine-shadow-sm)',
+            }}
+          >
+            <IconStethoscope size={21} color="white" />
+          </Box>
+          <Box>
+            <Text
+              fw={700}
+              ff="Fraunces, serif"
+              fz="lg"
+              lh={1.1}
+              style={{ color: tokens.ink }}
+            >
+              Construe Type-Ahead
+            </Text>
+            <Text size="xs" c="slate.6" lh={1.1}>
+              Plain language in · coded concepts out
+            </Text>
+          </Box>
+        </Group>
+
+        {/* Screen switch */}
+        <SegmentedControl
+          value={screen}
+          onChange={(v) => onChangeScreen(v as Screen)}
+          radius="lg"
+          color="teal"
+          data={[
+            { label: 'Encounter note', value: 'encounter' },
+            { label: 'Orders', value: 'orders' },
+          ]}
+        />
+
+        {/* Controls */}
+        <Group gap="md" wrap="nowrap">
+          <Tooltip
+            label={
+              liveReady
+                ? 'Live calls the Construe API with your credentials'
+                : 'Add credentials in Settings to enable Live mode'
+            }
+            withArrow
+          >
+            <SegmentedControl
+              value={demoMode ? 'demo' : 'live'}
+              onChange={(v) => setDemoMode(v === 'demo')}
+              radius="lg"
+              size="sm"
+              color={demoMode ? 'teal' : 'coral'}
+              data={[
+                { label: 'Demo', value: 'demo' },
+                { label: 'Live', value: 'live' },
+              ]}
+            />
+          </Tooltip>
+
+          <Switch
+            checked={showCodes}
+            onChange={(e) => setShowCodes(e.currentTarget.checked)}
+            color="teal"
+            size="md"
+            thumbIcon={
+              showCodes ? <IconCode size={12} color="var(--mantine-color-teal-7)" /> : undefined
+            }
+            label={
+              <Text size="sm" fw={600} c="slate.8">
+                Show codes
+              </Text>
+            }
+          />
+
+          {!demoMode && (
+            <Badge color={liveReady ? 'teal' : 'coral'} variant="light" radius="sm">
+              {liveReady ? 'Live' : 'No creds'}
+            </Badge>
+          )}
+
+          <Tooltip label="Connection settings" withArrow>
+            <ActionIcon
+              variant="default"
+              size="lg"
+              radius="md"
+              aria-label="Settings"
+              onClick={onOpenSettings}
+            >
+              <IconSettings size={19} />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
+      </Group>
+    </Box>
+  );
+}

--- a/construe-typeahead/src/demo/fixtures.ts
+++ b/construe-typeahead/src/demo/fixtures.ts
@@ -1,0 +1,183 @@
+import type {
+  CodeSystemSlug,
+  SearchResultItem,
+  SearchSystem,
+  TextSearchResponse,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Demo Mode fixtures.
+//
+// Baked data shaped exactly like a real Construe TextSearchResponse, so the app
+// is fully standalone with no creds. demoTextSearch() filters a per-system
+// catalog by substring — mirroring Construe's substring text search — so the
+// client-side ranking (api/ranking.ts) does the same work it does live.
+//
+// Coverage spans all four systems and deliberately includes co-occurrent
+// "noise" (e.g. asthma) so the ranking demo is visible:
+//   asth  → Asthma            (ICD-10-CM + SNOMED_CT_US_LITE)
+//   albut → Albuterol         (RXNORM)
+//   lipid panel → Lipid panel (LOINC)
+//   plus hypertension, diabetes, COPD, metformin, lisinopril, A1c, CBC, etc.
+// ---------------------------------------------------------------------------
+
+export const SYSTEM_META: Record<CodeSystemSlug, SearchSystem> = {
+  'ICD-10-CM': { name: 'ICD-10-CM', version: '2025' },
+  SNOMED_CT_US_LITE: { name: 'SNOMED CT US', version: '2024-09' },
+  RXNORM: { name: 'RxNorm', version: '2025-01' },
+  LOINC: { name: 'LOINC', version: '2.78' },
+};
+
+const CATALOG: Record<CodeSystemSlug, SearchResultItem[]> = {
+  'ICD-10-CM': [
+    { code: 'J45.909', description: 'Unspecified asthma, uncomplicated' },
+    { code: 'J45.901', description: 'Unspecified asthma with (acute) exacerbation' },
+    { code: 'J45.40', description: 'Moderate persistent asthma, uncomplicated' },
+    { code: 'J44.9', description: 'Chronic obstructive pulmonary disease, unspecified' },
+    { code: 'I10', description: 'Essential (primary) hypertension' },
+    { code: 'I11.9', description: 'Hypertensive heart disease without heart failure' },
+    { code: 'E11.9', description: 'Type 2 diabetes mellitus without complications' },
+    { code: 'E11.65', description: 'Type 2 diabetes mellitus with hyperglycemia' },
+    { code: 'E11.22', description: 'Type 2 diabetes mellitus with diabetic chronic kidney disease' },
+    { code: 'E78.5', description: 'Hyperlipidemia, unspecified' },
+  ],
+  SNOMED_CT_US_LITE: [
+    { code: '195967001', description: 'Asthma' },
+    { code: '389145006', description: 'Allergic asthma' },
+    { code: '304527002', description: 'Acute asthma' },
+    {
+      code: '708090002',
+      description: 'Acute exacerbation of asthma co-occurrent with allergic rhinitis',
+    },
+    { code: '195949008', description: 'Chronic asthmatic bronchitis' },
+    { code: '38341003', description: 'Hypertension' },
+    { code: '13644009', description: 'Hypercholesterolemia' },
+    { code: '73211009', description: 'Diabetes mellitus' },
+    { code: '44054006', description: 'Type 2 diabetes mellitus' },
+    { code: '13645005', description: 'Chronic obstructive lung disease' },
+  ],
+  RXNORM: [
+    { code: '435', description: 'Albuterol' },
+    { code: '801095', description: 'Albuterol 90 MCG/ACTUAT inhalation aerosol' },
+    { code: '745679', description: 'Albuterol 0.09 MG/ACTUAT metered dose inhaler' },
+    { code: '6809', description: 'Metformin' },
+    { code: '860975', description: 'Metformin hydrochloride 500 MG oral tablet' },
+    { code: '29046', description: 'Lisinopril' },
+    { code: '314076', description: 'Lisinopril 10 MG oral tablet' },
+    { code: '83367', description: 'Atorvastatin' },
+    { code: '617312', description: 'Atorvastatin 20 MG oral tablet' },
+  ],
+  LOINC: [
+    { code: '24331-1', description: 'Lipid panel' },
+    { code: '57698-3', description: 'Lipid panel with direct LDL - Serum or Plasma' },
+    { code: '4548-4', description: 'Hemoglobin A1c/Hemoglobin.total in Blood' },
+    { code: '2345-7', description: 'Glucose [Mass/volume] in Serum or Plasma' },
+    { code: '58410-2', description: 'CBC panel - Blood by Automated count' },
+    { code: '2160-0', description: 'Creatinine [Mass/volume] in Serum or Plasma' },
+    { code: '3016-3', description: 'Thyrotropin [Units/volume] in Serum or Plasma' },
+  ],
+};
+
+function buildResponse(
+  slug: CodeSystemSlug,
+  results: SearchResultItem[],
+  limit: number,
+): TextSearchResponse {
+  const clipped = results.slice(0, limit);
+  return { system: SYSTEM_META[slug], results: clipped, found: results.length };
+}
+
+/** Demo text search: case-insensitive substring match over the catalog. */
+export function demoTextSearch(
+  slug: CodeSystemSlug,
+  query: string,
+  limit = 8,
+): TextSearchResponse {
+  const q = query.trim().toLowerCase();
+  if (!q) return buildResponse(slug, [], limit);
+  const matches = CATALOG[slug].filter((item) =>
+    item.description.toLowerCase().includes(q),
+  );
+  return buildResponse(slug, matches, limit);
+}
+
+// ---------------------------------------------------------------------------
+// Demo semantic search (note field). Real semantic search matches by meaning,
+// not substring — so we map clinical phrasing to SNOMED concepts via keyword
+// triggers. Each trigger can surface multiple related concepts.
+// ---------------------------------------------------------------------------
+interface SemanticTrigger {
+  match: string[];
+  concepts: SearchResultItem[];
+}
+
+const SEMANTIC_TRIGGERS: SemanticTrigger[] = [
+  {
+    match: ['short of breath', 'shortness of breath', 'sob', 'dyspnea', 'breathless'],
+    concepts: [
+      { code: '267036007', description: 'Dyspnea' },
+      { code: '60845006', description: 'Dyspnea on exertion' },
+    ],
+  },
+  {
+    match: ['wheez'],
+    concepts: [{ code: '56018004', description: 'Wheezing' }],
+  },
+  {
+    match: ['chest pain', 'chest tightness'],
+    concepts: [
+      { code: '29857009', description: 'Chest pain' },
+      { code: '23924001', description: 'Heavy feeling in chest' },
+    ],
+  },
+  {
+    match: ['cough'],
+    concepts: [
+      { code: '49727002', description: 'Cough' },
+      { code: '11833005', description: 'Dry cough' },
+    ],
+  },
+  {
+    match: ['fever', 'febrile'],
+    concepts: [{ code: '386661006', description: 'Fever' }],
+  },
+  {
+    match: ['headache', 'head ache'],
+    concepts: [{ code: '25064002', description: 'Headache' }],
+  },
+  {
+    match: ['fatigue', 'tired', 'exhausted'],
+    concepts: [{ code: '84229001', description: 'Fatigue' }],
+  },
+  {
+    match: ['nausea', 'nauseous'],
+    concepts: [{ code: '422587007', description: 'Nausea' }],
+  },
+  {
+    match: ['dizz', 'lightheaded', 'light-headed'],
+    concepts: [{ code: '404640003', description: 'Dizziness' }],
+  },
+  {
+    match: ['palpitation'],
+    concepts: [{ code: '80313002', description: 'Palpitations' }],
+  },
+];
+
+export function demoSemanticSearch(query: string, limit = 8): TextSearchResponse {
+  const q = query.trim().toLowerCase();
+  const seen = new Set<string>();
+  const results: SearchResultItem[] = [];
+  if (q.length >= 3) {
+    for (const trigger of SEMANTIC_TRIGGERS) {
+      if (trigger.match.some((m) => q.includes(m))) {
+        for (const concept of trigger.concepts) {
+          if (!seen.has(concept.code)) {
+            seen.add(concept.code);
+            results.push(concept);
+          }
+        }
+      }
+    }
+  }
+  return buildResponse('SNOMED_CT_US_LITE', results, limit);
+}

--- a/construe-typeahead/src/hooks/useAppState.tsx
+++ b/construe-typeahead/src/hooks/useAppState.tsx
@@ -1,0 +1,123 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  DEFAULT_SETTINGS,
+  type CodedConcept,
+  type CommittedEntry,
+  type FieldKind,
+  type Settings,
+} from '../types';
+import { clearToken } from '../api/construe';
+
+// Seed Settings from Vite env vars (.env) when present, else DEFAULT_SETTINGS.
+// Keeping the Settings shape stable lets a localStorage build swap only the
+// storage layer without touching these signatures.
+function initialSettings(): Settings {
+  return {
+    clientId: import.meta.env.VITE_PHENOML_CLIENT_ID ?? DEFAULT_SETTINGS.clientId,
+    clientSecret:
+      import.meta.env.VITE_PHENOML_CLIENT_SECRET ?? DEFAULT_SETTINGS.clientSecret,
+    baseUrl: import.meta.env.VITE_PHENOML_BASE_URL || DEFAULT_SETTINGS.baseUrl,
+  };
+}
+
+let idCounter = 0;
+function makeId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  idCounter += 1;
+  return `e${idCounter}`;
+}
+
+interface AppState {
+  // Config
+  settings: Settings;
+  updateSettings: (next: Settings) => void;
+  demoMode: boolean;
+  setDemoMode: (on: boolean) => void;
+  showCodes: boolean;
+  setShowCodes: (on: boolean) => void;
+
+  // Committed-code store
+  entries: CommittedEntry[];
+  commit: (kind: FieldKind, text: string, codes: CodedConcept[]) => void;
+  removeEntry: (id: string) => void;
+  clearEntries: () => void;
+  entriesByKind: (kind: FieldKind) => CommittedEntry[];
+}
+
+const AppStateContext = createContext<AppState | null>(null);
+
+export function AppStateProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<Settings>(initialSettings);
+  const [demoMode, setDemoMode] = useState(true); // Demo Mode default ON
+  const [showCodes, setShowCodes] = useState(false); // hidden by default
+  const [entries, setEntries] = useState<CommittedEntry[]>([]);
+
+  const updateSettings = useCallback((next: Settings) => {
+    // Credentials/host changed → drop any cached token so the next live call
+    // re-authenticates against the new instance.
+    clearToken();
+    setSettings(next);
+  }, []);
+
+  const commit = useCallback(
+    (kind: FieldKind, text: string, codes: CodedConcept[]) => {
+      setEntries((prev) => [...prev, { id: makeId(), kind, text, codes }]);
+    },
+    [],
+  );
+
+  const removeEntry = useCallback((id: string) => {
+    setEntries((prev) => prev.filter((e) => e.id !== id));
+  }, []);
+
+  const clearEntries = useCallback(() => setEntries([]), []);
+
+  const entriesByKind = useCallback(
+    (kind: FieldKind) => entries.filter((e) => e.kind === kind),
+    [entries],
+  );
+
+  const value = useMemo<AppState>(
+    () => ({
+      settings,
+      updateSettings,
+      demoMode,
+      setDemoMode,
+      showCodes,
+      setShowCodes,
+      entries,
+      commit,
+      removeEntry,
+      clearEntries,
+      entriesByKind,
+    }),
+    [
+      settings,
+      updateSettings,
+      demoMode,
+      showCodes,
+      entries,
+      commit,
+      removeEntry,
+      clearEntries,
+      entriesByKind,
+    ],
+  );
+
+  return <AppStateContext.Provider value={value}>{children}</AppStateContext.Provider>;
+}
+
+export function useAppState(): AppState {
+  const ctx = useContext(AppStateContext);
+  if (!ctx) throw new Error('useAppState must be used within AppStateProvider');
+  return ctx;
+}

--- a/construe-typeahead/src/hooks/useTypeahead.ts
+++ b/construe-typeahead/src/hooks/useTypeahead.ts
@@ -1,0 +1,166 @@
+import { useEffect, useRef, useState } from 'react';
+import { useDebouncedValue } from '@mantine/hooks';
+import { searchSemantic, searchText } from '../api/construe';
+import { rankResults } from '../api/ranking';
+import { demoSemanticSearch, demoTextSearch } from '../demo/fixtures';
+import { useAppState } from './useAppState';
+import {
+  SearchError,
+  type CodeSystemSlug,
+  type CodedConcept,
+  type SearchErrorKind,
+  type SearchResultItem,
+  type SearchSystem,
+  type Suggestion,
+  type TextSearchResponse,
+} from '../types';
+
+export type SearchMode = 'text' | 'semantic';
+
+interface UseTypeaheadArgs {
+  /**
+   * Code systems to query. The FIRST is the display/primary system whose
+   * ranked results become the suggestion labels; any additional systems
+   * contribute their top-ranked concept so a single accepted suggestion can
+   * store codes across systems (e.g. problem list → SNOMED + ICD-10-CM).
+   */
+  systems: CodeSystemSlug[];
+  mode: SearchMode;
+  /** Minimum trimmed query length before a search fires. */
+  minLength?: number;
+}
+
+export interface TypeaheadState {
+  query: string;
+  setQuery: (q: string) => void;
+  suggestions: Suggestion[];
+  loading: boolean;
+  error: { kind: SearchErrorKind; message: string } | null;
+  reset: () => void;
+}
+
+function toConcept(system: SearchSystem, item: SearchResultItem): CodedConcept {
+  return {
+    system: system.name,
+    version: system.version,
+    code: item.code,
+    description: item.description,
+  };
+}
+
+function buildSuggestions(
+  query: string,
+  systems: CodeSystemSlug[],
+  responses: Record<string, TextSearchResponse>,
+  mode: SearchMode,
+): Suggestion[] {
+  const [primarySlug, ...secondarySlugs] = systems;
+  const primary = responses[primarySlug];
+  if (!primary) return [];
+
+  // Semantic results are already ranked by meaning server-side; only re-rank
+  // substring-based text results.
+  const primaryItems =
+    mode === 'text' ? rankResults(query, primary.results) : primary.results;
+
+  // Each additional system contributes its single best concept for the query,
+  // so accepting one suggestion stores codes across all configured systems.
+  const secondaryTops: CodedConcept[] = [];
+  for (const slug of secondarySlugs) {
+    const resp = responses[slug];
+    if (!resp || resp.results.length === 0) continue;
+    const ranked = mode === 'text' ? rankResults(query, resp.results) : resp.results;
+    secondaryTops.push(toConcept(resp.system, ranked[0]));
+  }
+
+  return primaryItems.map((item) => ({
+    id: `${primarySlug}:${item.code}`,
+    label: item.description,
+    codes: [toConcept(primary.system, item), ...secondaryTops],
+  }));
+}
+
+export function useTypeahead({
+  systems,
+  mode,
+  minLength = 2,
+}: UseTypeaheadArgs): TypeaheadState {
+  const { settings, demoMode } = useAppState();
+  const [query, setQuery] = useState('');
+  const [debounced] = useDebouncedValue(query, 250);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] =
+    useState<{ kind: SearchErrorKind; message: string } | null>(null);
+
+  // Guards against out-of-order responses clobbering newer ones.
+  const reqId = useRef(0);
+  const systemsKey = systems.join(',');
+
+  useEffect(() => {
+    const q = debounced.trim();
+    if (q.length < minLength) {
+      setSuggestions([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    const myReq = ++reqId.current;
+    setLoading(true);
+    setError(null);
+
+    async function fetchSystem(slug: CodeSystemSlug): Promise<TextSearchResponse> {
+      if (demoMode) {
+        return mode === 'semantic'
+          ? demoSemanticSearch(q)
+          : demoTextSearch(slug, q);
+      }
+      return mode === 'semantic'
+        ? searchSemantic(settings, slug, q)
+        : searchText(settings, slug, q);
+    }
+
+    (async () => {
+      try {
+        const [primarySlug, ...secondarySlugs] = systems;
+        // Primary failure surfaces an error; secondary failures degrade quietly
+        // (e.g. one system returns 501) so the primary still works.
+        const primaryResp = await fetchSystem(primarySlug);
+        const secondarySettled = await Promise.allSettled(
+          secondarySlugs.map((s) => fetchSystem(s)),
+        );
+
+        const responses: Record<string, TextSearchResponse> = {
+          [primarySlug]: primaryResp,
+        };
+        secondarySettled.forEach((res, i) => {
+          if (res.status === 'fulfilled') responses[secondarySlugs[i]] = res.value;
+        });
+
+        if (myReq !== reqId.current) return;
+        setSuggestions(buildSuggestions(q, systems, responses, mode));
+        setLoading(false);
+      } catch (err) {
+        if (myReq !== reqId.current) return;
+        const kind: SearchErrorKind =
+          err instanceof SearchError ? err.kind : 'unknown';
+        const message =
+          err instanceof Error ? err.message : 'Something went wrong.';
+        setError({ kind, message });
+        setSuggestions([]);
+        setLoading(false);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debounced, demoMode, settings, mode, systemsKey, minLength]);
+
+  function reset() {
+    setQuery('');
+    setSuggestions([]);
+    setError(null);
+    setLoading(false);
+  }
+
+  return { query, setQuery, suggestions, loading, error, reset };
+}

--- a/construe-typeahead/src/main.tsx
+++ b/construe-typeahead/src/main.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { MantineProvider } from '@mantine/core';
+import '@mantine/core/styles.css';
+import './styles.css';
+import { theme } from './theme';
+import { AppStateProvider } from './hooks/useAppState';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <MantineProvider theme={theme} defaultColorScheme="light">
+      <AppStateProvider>
+        <App />
+      </AppStateProvider>
+    </MantineProvider>
+  </React.StrictMode>,
+);

--- a/construe-typeahead/src/screens/EncounterScreen.tsx
+++ b/construe-typeahead/src/screens/EncounterScreen.tsx
@@ -1,0 +1,50 @@
+import { Badge, Stack } from '@mantine/core';
+import { Panel } from '../components/Panel';
+import { RowBuilder } from '../components/RowBuilder';
+import { NoteField } from '../components/NoteField';
+import type { CodeSystemSlug } from '../types';
+
+// Problem list runs BOTH systems — SNOMED is the display/ranking system (its
+// plain "Asthma" should beat the co-occurrent descriptors), and the top
+// ICD-10-CM hit is attached so each problem stores both codes.
+const PROBLEM_SYSTEMS: CodeSystemSlug[] = ['SNOMED_CT_US_LITE', 'ICD-10-CM'];
+const MEDICATION_SYSTEMS: CodeSystemSlug[] = ['RXNORM'];
+
+export function EncounterScreen() {
+  return (
+    <Stack gap="lg">
+      <Panel
+        title="Problem list"
+        accent={<Badge variant="light" color="slate" radius="sm">SNOMED CT · ICD-10-CM</Badge>}
+      >
+        <RowBuilder
+          kind="problem"
+          systems={PROBLEM_SYSTEMS}
+          label="Add a problem"
+          hint="Type a condition — e.g. “asth”. Each problem is stored as both a SNOMED and an ICD-10-CM code."
+          placeholder="Start typing a condition…"
+        />
+      </Panel>
+
+      <Panel
+        title="Medications"
+        accent={<Badge variant="light" color="slate" radius="sm">RxNorm</Badge>}
+      >
+        <RowBuilder
+          kind="medication"
+          systems={MEDICATION_SYSTEMS}
+          label="Add a medication"
+          hint="Type a drug name — e.g. “albut”."
+          placeholder="Start typing a medication…"
+        />
+      </Panel>
+
+      <Panel
+        title="Clinical note"
+        accent={<Badge variant="light" color="slate" radius="sm">SNOMED CT · semantic</Badge>}
+      >
+        <NoteField />
+      </Panel>
+    </Stack>
+  );
+}

--- a/construe-typeahead/src/screens/OrdersScreen.tsx
+++ b/construe-typeahead/src/screens/OrdersScreen.tsx
@@ -1,0 +1,25 @@
+import { Badge, Stack } from '@mantine/core';
+import { Panel } from '../components/Panel';
+import { RowBuilder } from '../components/RowBuilder';
+import type { CodeSystemSlug } from '../types';
+
+const ORDER_SYSTEMS: CodeSystemSlug[] = ['LOINC'];
+
+export function OrdersScreen() {
+  return (
+    <Stack gap="lg">
+      <Panel
+        title="Order entry"
+        accent={<Badge variant="light" color="slate" radius="sm">LOINC</Badge>}
+      >
+        <RowBuilder
+          kind="order"
+          systems={ORDER_SYSTEMS}
+          label="Add an order"
+          hint="Type a lab or panel — e.g. “lipid panel”. The same accept-commits-code pattern, coded to LOINC."
+          placeholder="Start typing an order…"
+        />
+      </Panel>
+    </Stack>
+  );
+}

--- a/construe-typeahead/src/styles.css
+++ b/construe-typeahead/src/styles.css
@@ -1,0 +1,83 @@
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #102a43;
+  background:
+    radial-gradient(1200px 600px at 12% -8%, #e0f7f1 0%, rgba(224, 247, 241, 0) 60%),
+    radial-gradient(900px 500px at 105% 0%, #ffe9e2 0%, rgba(255, 233, 226, 0) 55%),
+    linear-gradient(180deg, #f6f9fb 0%, #eef2f6 100%);
+  background-attachment: fixed;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* Suggestion dropdown entrance */
+@keyframes ct-pop-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* The "code reveal" flip — a deliberate flip, not a plain show/hide */
+@keyframes ct-flip-in {
+  from {
+    opacity: 0;
+    transform: rotateX(-75deg);
+  }
+  to {
+    opacity: 1;
+    transform: rotateX(0deg);
+  }
+}
+
+@keyframes ct-chip-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.ct-pop-in {
+  animation: ct-pop-in 140ms cubic-bezier(0.2, 0.9, 0.3, 1);
+  transform-origin: top center;
+}
+
+.ct-flip-in {
+  animation: ct-flip-in 280ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  transform-origin: top center;
+}
+
+.ct-chip-in {
+  animation: ct-chip-in 180ms cubic-bezier(0.2, 0.9, 0.3, 1) both;
+}
+
+/* Subtle eyebrow letterspacing used on section labels */
+.ct-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 11px;
+  font-weight: 700;
+}

--- a/construe-typeahead/src/theme.ts
+++ b/construe-typeahead/src/theme.ts
@@ -1,0 +1,85 @@
+import { createTheme, type MantineColorsTuple } from '@mantine/core';
+
+// Bespoke palette so the app doesn't read as default Mantine.
+// Primary: a deep clinical teal. Accent: a warm coral for the "coded" moments.
+const teal: MantineColorsTuple = [
+  '#e4faf4',
+  '#c3f0e6',
+  '#97e5d4',
+  '#67d9c0',
+  '#42cfb1',
+  '#2ec7a7',
+  '#1fb89a',
+  '#0f9e84',
+  '#00806b',
+  '#005f50',
+];
+
+const coral: MantineColorsTuple = [
+  '#fff0ec',
+  '#ffded4',
+  '#ffbaa8',
+  '#ff9377',
+  '#fd724e',
+  '#fc5d34',
+  '#fc5126',
+  '#e14219',
+  '#c93812',
+  '#b02c07',
+];
+
+// Cool slate for surfaces and text.
+const slate: MantineColorsTuple = [
+  '#f5f7f9',
+  '#e9edf1',
+  '#cfd8e0',
+  '#b2c0cd',
+  '#98abbc',
+  '#869cb0',
+  '#7c93aa',
+  '#697f95',
+  '#5b7185',
+  '#4a6175',
+];
+
+export const theme = createTheme({
+  primaryColor: 'teal',
+  primaryShade: 7,
+  colors: { teal, coral, slate },
+  fontFamily:
+    "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+  fontFamilyMonospace:
+    "'JetBrains Mono', 'SF Mono', 'Fira Code', ui-monospace, monospace",
+  headings: {
+    fontFamily: "Fraunces, Georgia, 'Times New Roman', serif",
+    fontWeight: '600',
+  },
+  defaultRadius: 'lg',
+  radius: {
+    xs: '6px',
+    sm: '9px',
+    md: '12px',
+    lg: '16px',
+    xl: '22px',
+  },
+  shadows: {
+    xs: '0 1px 2px rgba(16, 42, 67, 0.06)',
+    sm: '0 2px 8px rgba(16, 42, 67, 0.08)',
+    md: '0 8px 24px rgba(16, 42, 67, 0.10)',
+    lg: '0 18px 48px rgba(16, 42, 67, 0.14)',
+    xl: '0 28px 72px rgba(16, 42, 67, 0.18)',
+  },
+  cursorType: 'pointer',
+});
+
+// Shared design tokens used outside Mantine props (inline styles / gradients).
+export const tokens = {
+  ink: '#102a43',
+  inkSoft: '#486581',
+  surface: '#ffffff',
+  canvas: '#eef2f6',
+  canvasTop: '#f6f9fb',
+  border: '#dbe3ec',
+  codeBg: '#0f2233',
+  codeInk: '#7fe8d2',
+};

--- a/construe-typeahead/src/types.ts
+++ b/construe-typeahead/src/types.ts
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------
+// Settings — keep this shape EXACTLY. The Claude artifact sandbox blocks
+// localStorage, so we back it with React state, but these signatures stay
+// identical so the app ports to a localStorage build unchanged.
+// ---------------------------------------------------------------------------
+export type Settings = { clientId: string; clientSecret: string; baseUrl: string };
+
+export const DEFAULT_SETTINGS: Settings = {
+  clientId: '',
+  clientSecret: '',
+  baseUrl: 'https://experiment.app.pheno.ml',
+};
+
+// ---------------------------------------------------------------------------
+// Construe code systems (exact path slugs — do not alter)
+// ---------------------------------------------------------------------------
+export type CodeSystemSlug =
+  | 'ICD-10-CM'
+  | 'SNOMED_CT_US_LITE'
+  | 'RXNORM'
+  | 'LOINC';
+
+// ---------------------------------------------------------------------------
+// API response shapes (confirmed against docs — do not invent fields).
+// GET /construe/codes/{codesystem}/search/{text|semantic}?q=&limit=
+//   { system: { name, version }, results: [ { code, description } ], found }
+// The system name/version lives on the PARENT system object, not per result.
+// ---------------------------------------------------------------------------
+export interface SearchSystem {
+  name: string;
+  version: string;
+}
+
+export interface SearchResultItem {
+  code: string;
+  description: string;
+}
+
+export interface TextSearchResponse {
+  system: SearchSystem;
+  results: SearchResultItem[];
+  found: number;
+}
+
+// A stored coded concept: system.name + result.code + result.description.
+export interface CodedConcept {
+  system: string; // system.name
+  version: string; // system.version
+  code: string;
+  description: string;
+}
+
+// A single ranked suggestion shown in the type-ahead dropdown / chip rail.
+// Carries the coded concept(s) it would commit when accepted.
+export interface Suggestion {
+  /** Stable key for React lists. */
+  id: string;
+  /** Human-readable label shown to the clinician. */
+  label: string;
+  /** Coded concept(s) committed when this suggestion is accepted. */
+  codes: CodedConcept[];
+}
+
+// Field categories — drive which code system(s) / endpoint a field uses.
+export type FieldKind = 'problem' | 'medication' | 'order' | 'note';
+
+// A committed entry in the in-memory store. `text` is what the UI shows;
+// `codes` is the structured data revealed by the Show-codes toggle.
+export interface CommittedEntry {
+  id: string;
+  kind: FieldKind;
+  text: string;
+  codes: CodedConcept[];
+}
+
+// Error categories surfaced to the UI for graceful handling.
+export type SearchErrorKind =
+  | 'auth' // 401 after re-auth attempt
+  | 'not_found' // 404 code system not found
+  | 'not_configured' // 501 text search not configured
+  | 'network' // fetch/CORS failure
+  | 'unknown';
+
+export class SearchError extends Error {
+  kind: SearchErrorKind;
+  status?: number;
+  constructor(kind: SearchErrorKind, message: string, status?: number) {
+    super(message);
+    this.name = 'SearchError';
+    this.kind = kind;
+    this.status = status;
+  }
+}

--- a/construe-typeahead/src/vite-env.d.ts
+++ b/construe-typeahead/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_PHENOML_CLIENT_ID?: string;
+  readonly VITE_PHENOML_CLIENT_SECRET?: string;
+  readonly VITE_PHENOML_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/construe-typeahead/tsconfig.json
+++ b/construe-typeahead/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/construe-typeahead/vite.config.ts
+++ b/construe-typeahead/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// Standalone SPA (unlike sibling demochat, which is a library build).
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    open: true,
+  },
+})


### PR DESCRIPTION
A new standalone Vite + React + TypeScript + Mantine demo (`construe-typeahead/`) where a clinician types plain language and the app silently stores structured medical codes via PhenoML Construe text and semantic search. It has two screens — an Encounter note (dual-coded SNOMED + ICD-10-CM problem list, RxNorm meds, and a semantic SNOMED chip-rail note) and Orders (LOINC) — with a Show-codes toggle that reveals the stored `system · code · description` behind each entry. Demo Mode (baked fixtures, default on) runs with no credentials, while Live mode uses `.env`- or Settings-driven creds with a cached OAuth token, debounced calls, and client-side re-ranking so plain concepts beat co-occurrent descriptors. Robust handling for 401/404/501/CORS/empty results is included, and the README documents setup, the CORS caveat, and the localStorage-port note. Verified via typecheck, production build, and a headless-browser smoke test of the full Demo Mode flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)