### PR TITLE
Clean up Problem-list type-ahead display text

### DIFF
--- a/construe-typeahead/src/api/labels.ts
+++ b/construe-typeahead/src/api/labels.ts
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------
+// Display-text cleaning.
+//
+// Code-system descriptions often carry parenthetical qualifiers that read as
+// clutter to a clinician, e.g. "Unspecified asthma with (acute) exacerbation"
+// or "Essential (primary) hypertension". For display we strip those "(...)"
+// segments and tidy the surrounding whitespace/punctuation so the label reads
+// as plain human text. The underlying CODE is never touched — only the text.
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip "(...)" qualifiers from a description and tidy whitespace/punctuation.
+ * Pure function so it is trivially testable.
+ *
+ *   "Unspecified asthma with (acute) exacerbation" -> "Unspecified asthma with exacerbation"
+ *   "Essential (primary) hypertension"             -> "Essential hypertension"
+ *   "Asthma"                                        -> "Asthma" (unchanged)
+ */
+export function cleanDisplay(description: string): string {
+  const cleaned = description
+    .replace(/\s*\([^)]*\)/g, '') // drop " (qualifier)" segments
+    .replace(/\s{2,}/g, ' ') // collapse doubled spaces
+    .replace(/\s+([,;])/g, '$1') // fix stray space before a comma/semicolon
+    .trim();
+
+  // If the description was entirely parenthetical, never render blank.
+  return cleaned || description;
+}

--- a/construe-typeahead/src/components/RowBuilder.tsx
+++ b/construe-typeahead/src/components/RowBuilder.tsx
@@ -16,6 +16,8 @@ interface RowBuilderProps {
   hint: string;
   placeholder: string;
   minLength?: number;
+  /** Strip parenthetical qualifiers from displayed labels/code descriptions. */
+  cleanLabels?: boolean;
 }
 
 // Generic "type a phrase → pick a ranked suggestion → commit display text +
@@ -28,12 +30,14 @@ export function RowBuilder({
   hint,
   placeholder,
   minLength = 2,
+  cleanLabels = false,
 }: RowBuilderProps) {
   const { commit, showCodes, entriesByKind } = useAppState();
   const { query, setQuery, suggestions, loading, error, reset } = useTypeahead({
     systems,
     mode,
     minLength,
+    cleanLabels,
   });
   const [focused, setFocused] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);

--- a/construe-typeahead/src/hooks/useTypeahead.ts
+++ b/construe-typeahead/src/hooks/useTypeahead.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useDebouncedValue } from '@mantine/hooks';
 import { searchSemantic, searchText } from '../api/construe';
 import { rankResults } from '../api/ranking';
+import { cleanDisplay } from '../api/labels';
 import { demoSemanticSearch, demoTextSearch } from '../demo/fixtures';
 import { useAppState } from './useAppState';
 import {
@@ -28,6 +29,12 @@ interface UseTypeaheadArgs {
   mode: SearchMode;
   /** Minimum trimmed query length before a search fires. */
   minLength?: number;
+  /**
+   * When true, strip parenthetical qualifiers from the displayed label and
+   * code descriptions (e.g. "Essential (primary) hypertension" →
+   * "Essential hypertension"). Codes are never altered — display text only.
+   */
+  cleanLabels?: boolean;
 }
 
 export interface TypeaheadState {
@@ -53,10 +60,16 @@ function buildSuggestions(
   systems: CodeSystemSlug[],
   responses: Record<string, TextSearchResponse>,
   mode: SearchMode,
+  cleanLabels: boolean,
 ): Suggestion[] {
   const [primarySlug, ...secondarySlugs] = systems;
   const primary = responses[primarySlug];
   if (!primary) return [];
+
+  // Ranking runs on the RAW description; cleaning is applied afterwards to the
+  // text that ships to the UI, so display tidying never changes result order.
+  const shape = (item: SearchResultItem): SearchResultItem =>
+    cleanLabels ? { ...item, description: cleanDisplay(item.description) } : item;
 
   // Semantic results are already ranked by meaning server-side; only re-rank
   // substring-based text results.
@@ -70,20 +83,24 @@ function buildSuggestions(
     const resp = responses[slug];
     if (!resp || resp.results.length === 0) continue;
     const ranked = mode === 'text' ? rankResults(query, resp.results) : resp.results;
-    secondaryTops.push(toConcept(resp.system, ranked[0]));
+    secondaryTops.push(toConcept(resp.system, shape(ranked[0])));
   }
 
-  return primaryItems.map((item) => ({
-    id: `${primarySlug}:${item.code}`,
-    label: item.description,
-    codes: [toConcept(primary.system, item), ...secondaryTops],
-  }));
+  return primaryItems.map((item) => {
+    const shaped = shape(item);
+    return {
+      id: `${primarySlug}:${item.code}`,
+      label: shaped.description,
+      codes: [toConcept(primary.system, shaped), ...secondaryTops],
+    };
+  });
 }
 
 export function useTypeahead({
   systems,
   mode,
   minLength = 2,
+  cleanLabels = false,
 }: UseTypeaheadArgs): TypeaheadState {
   const { settings, demoMode } = useAppState();
   const [query, setQuery] = useState('');
@@ -139,7 +156,7 @@ export function useTypeahead({
         });
 
         if (myReq !== reqId.current) return;
-        setSuggestions(buildSuggestions(q, systems, responses, mode));
+        setSuggestions(buildSuggestions(q, systems, responses, mode, cleanLabels));
         setLoading(false);
       } catch (err) {
         if (myReq !== reqId.current) return;
@@ -153,7 +170,7 @@ export function useTypeahead({
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debounced, demoMode, settings, mode, systemsKey, minLength]);
+  }, [debounced, demoMode, settings, mode, systemsKey, minLength, cleanLabels]);
 
   function reset() {
     setQuery('');

--- a/construe-typeahead/src/screens/EncounterScreen.tsx
+++ b/construe-typeahead/src/screens/EncounterScreen.tsx
@@ -20,6 +20,7 @@ export function EncounterScreen() {
         <RowBuilder
           kind="problem"
           systems={PROBLEM_SYSTEMS}
+          cleanLabels
           label="Add a problem"
           hint="Type a condition — e.g. “asth”. Each problem is stored as both a SNOMED and an ICD-10-CM code."
           placeholder="Start typing a condition…"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "chennai",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Strips parenthetical qualifiers from the Problem-list type-ahead so clinical descriptions read as plain human text (e.g. `Essential (primary) hypertension` → `Essential hypertension`, `Unspecified asthma with (acute) exacerbation` → `Unspecified asthma with exacerbation`). A new pure `cleanDisplay()` helper (`src/api/labels.ts`) does the stripping, applied in `useTypeahead`'s suggestion builder *after* ranking so it only touches displayed label/description text — the underlying codes are never altered. Cleaning is opt-in via a new `cleanLabels` flag on `RowBuilder`/`useTypeahead`, enabled only on the Problem-list field in `EncounterScreen`, so Medications and the Clinical note field are unchanged. Verified via `npm run typecheck`, `npm run build`, and manual demo-mode testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)