### PR TITLE
Add prior-auth review web UI for MOPA breast-cancer demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ This repository contains demos built with phenoml!
 - Demonstrates processing structured healthcare data and mapping to standardized coding systems
 - See the [README](trial-protocol-coding/README.md) for setup and usage instructions
 
+### :dna: MOPA Lang2FHIR oncology package
+**Location:** `mopa-lang2fhir`
+
+**Key Features:**
+- Reuses the breast cancer prior-auth data from `mopa-breast-pa`
+- Shows which prior-auth artifacts feed a Lang2FHIR workflow
+- Builds an oncology FHIR Bundle, optionally writes it through PhenoML's FHIR Proxy, and runs FHIR2Summary IPS mode
+- Includes optional local OncoHealth demo profile upload
+
 ### about phenoml
 :sparkles: [phenoml](https://phenoml.com/) is a developer platform for healthcare AI. 
 

--- a/mopa-breast-pa/.gitignore
+++ b/mopa-breast-pa/.gitignore
@@ -8,3 +8,5 @@ cds_hooks_server/__pycache__/
 evals/__pycache__/
 evals/report.json
 evals/report.md
+ui/node_modules/
+ui/dist/

--- a/mopa-breast-pa/Makefile
+++ b/mopa-breast-pa/Makefile
@@ -1,0 +1,52 @@
+# MOPA breast-cancer prior-auth web UI — dev tasks.
+#
+#   make dev        run backend (:8001) + frontend (:5173) together; Ctrl+C stops both
+#   make setup      one-time: create the venv + install backend and frontend deps
+#   make backend    run only the FastAPI backend
+#   make frontend   run only the Vite dev server
+#
+# Requires `uv` (https://docs.astral.sh/uv) for the Python venv and `npm` for the frontend.
+
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+VENV := .venv
+UVICORN := $(VENV)/bin/uvicorn
+BACKEND_PORT ?= 8001
+
+# Create the venv and install backend deps whenever requirements.txt changes.
+$(VENV): requirements.txt
+	uv venv --python 3.12 $(VENV)
+	uv pip install --python $(VENV)/bin/python -r requirements.txt
+	@touch $(VENV)
+
+# Install frontend deps whenever package.json changes.
+ui/node_modules: ui/package.json
+	cd ui && npm install
+	@touch ui/node_modules
+
+.PHONY: setup
+setup: $(VENV) ui/node_modules ## Create the venv + install backend and frontend deps
+
+.PHONY: backend
+backend: $(VENV) ## Run the FastAPI backend on :8001
+	$(UVICORN) ui_server:app --port $(BACKEND_PORT) --reload
+
+.PHONY: frontend
+frontend: ui/node_modules ## Run the Vite dev server on :5173
+	cd ui && npm run dev
+
+.PHONY: dev
+dev: setup ## Run backend + frontend together (Ctrl+C stops both)
+	@echo "backend  -> http://localhost:$(BACKEND_PORT)"
+	@echo "frontend -> http://localhost:5173   (open this one)"
+	@echo "Ctrl+C stops both."
+	@trap 'kill 0' EXIT INT TERM; \
+	  $(UVICORN) ui_server:app --port $(BACKEND_PORT) --reload & \
+	  ( cd ui && npm run dev ) & \
+	  wait
+
+.PHONY: help
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+	  | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'

--- a/mopa-breast-pa/README.md
+++ b/mopa-breast-pa/README.md
@@ -122,6 +122,16 @@ The same pipeline, wrapped in a two-persona web app. **Medplum is the EHR / syst
 - **Provider view** — paste a pathology report → watch lang2fhir/construe/IPS + the readiness gap-check flag **HER2 missing** → enter the resolved HER2 (written back to the EHR) → **submit** a preauthorization Claim.
 - **Payer view** — a **queue** of submitted Claims → open one → get the **OncoHealth UM-9 recommendation** (rebuilds the order-sign CDS Hooks envelope and runs [`cds_hooks_server/evaluate.py`](./cds_hooks_server/evaluate.py)) with rationale + the pre-approval Coverage → **Approve / Deny** (human-in-the-loop; you can override the AI). A **HER2 what-if toggle** flips the receptor status and shows the recommendation change live.
 
+**Quickest start** — the [`Makefile`](./Makefile) runs the backend (`:8001`) and frontend (`:5173`) together; Ctrl+C stops both:
+
+```bash
+make dev        # first run also creates the venv + installs deps (needs `uv` and `npm`)
+```
+
+Then open http://localhost:5173. Other targets: `make setup` (install deps only), `make backend`, `make frontend`, `make help`.
+
+Or run the two processes yourself in separate shells:
+
 **Backend** ([`ui_server.py`](./ui_server.py)) — reuses the same `.env` credentials and builds the UM-9 + readiness agents **once at startup**:
 
 ```bash

--- a/mopa-breast-pa/README.md
+++ b/mopa-breast-pa/README.md
@@ -115,6 +115,29 @@ CDS_HOOKS_URL=http://localhost:8088 .venv/bin/python step2_cdshooks.py   # POST 
 
 ---
 
+## Web UI (provider submit + payer review)
+
+The same pipeline, wrapped in a two-persona web app. **Medplum is the EHR / system of record** (reached *through* PhenoML — `client.fhir.*` proxies to the registered FHIR provider); this app only handles the **prior-auth submission and review**. Prior auth is modeled the standard FHIR way: a **Claim** (`use=preauthorization`) is the submission and the payer's queue item, and a **ClaimResponse** (with a **Coverage** on approval) records the decision.
+
+- **Provider view** — paste a pathology report → watch lang2fhir/construe/IPS + the readiness gap-check flag **HER2 missing** → enter the resolved HER2 (written back to the EHR) → **submit** a preauthorization Claim.
+- **Payer view** — a **queue** of submitted Claims → open one → get the **OncoHealth UM-9 recommendation** (rebuilds the order-sign CDS Hooks envelope and runs [`cds_hooks_server/evaluate.py`](./cds_hooks_server/evaluate.py)) with rationale + the pre-approval Coverage → **Approve / Deny** (human-in-the-loop; you can override the AI). A **HER2 what-if toggle** flips the receptor status and shows the recommendation change live.
+
+**Backend** ([`ui_server.py`](./ui_server.py)) — reuses the same `.env` credentials and builds the UM-9 + readiness agents **once at startup**:
+
+```bash
+.venv/bin/uvicorn ui_server:app --port 8001 --reload    # needs a writable PHENOML_FHIR_PROVIDER_ID for the round-trip
+```
+
+**Frontend** ([`ui/`](./ui) — Vite + React + Mantine, mirrors the `demochat` stack):
+
+```bash
+cd ui && npm install && npm run dev                     # http://localhost:5173 (proxies /api → :8001)
+```
+
+> On a **read-only** FHIR instance the Claim/ClaimResponse writes degrade to a local registry (`.state/claims.json`) so the demo still runs end-to-end; each queue row shows whether it was persisted to Medplum.
+
+---
+
 ## What's in this repo
 
 | Path | What it is |
@@ -124,6 +147,10 @@ CDS_HOOKS_URL=http://localhost:8088 .venv/bin/python step2_cdshooks.py   # POST 
 | [`step2_cdshooks.py`](./step2_cdshooks.py) | Phase 2 - assemble the order-select envelope and post it to the oncology-crd service (Response A / B) |
 | [`step3_ordersign.py`](./step3_ordersign.py) | Phase 3 - order-sign → pre-approved + Coverage, then a HER2-negative DENY contrast |
 | [`run_demo.py`](./run_demo.py) | Runs all four phases in one process |
+| [`pipeline.py`](./pipeline.py) | Return-based intake + readiness logic (shared by the step scripts and the web backend) |
+| [`ui_server.py`](./ui_server.py) | FastAPI backend for the web UI — intake / submit / queue / recommendation / decision |
+| [`pa_fhir.py`](./pa_fhir.py) | Prior-auth persistence: Claim / ClaimResponse / Coverage builders + Medplum read/write with a read-only fallback |
+| [`ui/`](./ui) | The provider + payer web app (Vite + React + Mantine) |
 | [`common.py`](./common.py) | Shared config/auth/helpers + the `.state/` artifact store the steps pass data through (reused from the TMS demo) |
 | [`cds_hooks_server/main.py`](./cds_hooks_server/main.py) | The FastAPI CDS Hooks shim - discovery + the oncology-crd service |
 | [`cds_hooks_server/evaluate.py`](./cds_hooks_server/evaluate.py) | The judgment: resolve the Library, check DataRequirements, call the UM-9 agent, build the cards |

--- a/mopa-breast-pa/pa_fhir.py
+++ b/mopa-breast-pa/pa_fhir.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Prior-auth persistence layer for the MOPA web UI: Claim (submission) + ClaimResponse (decision).
+
+The step-script demo produces CDS Hooks cards + a Coverage systemAction but nothing durable to build
+a review queue on. The UI needs a persistent prior-auth request, so this module models it the
+standard FHIR / Da Vinci PAS way:
+
+  - Claim (use=preauthorization)  -> the provider's submission (the payer's queue item)
+  - ClaimResponse (request->Claim) -> the reviewer's decision (approved / denied)
+  - Coverage                       -> written on approval (the pre-approval record)
+
+Medplum (reached THROUGH PhenoML: client.fhir.* proxies to the registered FHIR provider) is the
+system of record. Because writing needs a dedicated instance, every write degrades gracefully: on a
+read-only provider the resource is not persisted but a local registry (.state/claims.json) keeps the
+demo fully functional. The registry also holds the intake "snapshot" (chart + regimen + library +
+resolved HER2) the reviewer needs to rebuild the CDS Hooks envelope and re-run the UM-9 judgment.
+"""
+import json, uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from common import as_dict
+
+HERE = Path(__file__).resolve().parent
+CLAIMS_FILE = HERE / ".state" / "claims.json"
+
+CLAIM_TYPE = {"coding": [{"system": "http://terminology.hl7.org/CodeSystem/claim-type",
+                          "code": "professional"}]}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------- local registry (queue + snapshot; survives restart & read-only) ----
+def _load_registry() -> dict:
+    if CLAIMS_FILE.exists():
+        return json.loads(CLAIMS_FILE.read_text())
+    return {"claims": {}}
+
+
+def _save_registry(reg: dict):
+    CLAIMS_FILE.parent.mkdir(exist_ok=True)
+    CLAIMS_FILE.write_text(json.dumps(reg, indent=2))
+
+
+def _created_id(resp) -> str | None:
+    """Pull the server-assigned id out of a fhir.create response (the created resource, or a
+    location-ish dict). Returns None if it cannot be found."""
+    d = as_dict(resp)
+    if isinstance(d, dict):
+        if d.get("id"):
+            return d["id"]
+        loc = (d.get("meta") or {}).get("versionId")  # not an id, but guard anyway
+        _ = loc
+    return None
+
+
+def _patient_ref(snapshot: dict) -> dict:
+    pid = snapshot.get("patient_id")
+    return {"reference": f"Patient/{pid}"} if pid else {"display": patient_name(snapshot)}
+
+
+def patient_name(snapshot: dict) -> str:
+    """Best-effort display name from the extracted Patient resource."""
+    for e in (snapshot.get("bundle") or {}).get("entry", []):
+        r = e.get("resource") or {}
+        if r.get("resourceType") == "Patient":
+            n = (r.get("name") or [{}])[0]
+            if n.get("text"):
+                return n["text"]
+            given = " ".join(n.get("given") or [])
+            return (given + " " + n.get("family", "")).strip() or "Unknown patient"
+    return "Unknown patient"
+
+
+# ---------- resource builders --------------------------------------------
+def build_claim(snapshot: dict, local_id: str) -> dict:
+    """A minimal-but-valid preauthorization Claim for the ordered regimen. The evidence snapshot
+    (IPS + readiness) rides along as an extension so the queue can show context without a re-fetch."""
+    regimen_text = ((snapshot.get("regimen_requestgroup") or {}).get("code") or {}).get(
+        "text", "TH (paclitaxel + trastuzumab)")
+    evidence = {"ips": (snapshot.get("ips_text") or "")[:4000],
+                "readiness": snapshot.get("readiness"),
+                "nccn_fact": snapshot.get("nccn_fact")}
+    return {
+        "resourceType": "Claim",
+        "identifier": [{"system": "https://mopa.demo/claim", "value": local_id}],
+        "status": "active",
+        "type": CLAIM_TYPE,
+        "use": "preauthorization",
+        "patient": _patient_ref(snapshot),
+        "created": _now(),
+        "provider": {"display": "Lakeside Oncology"},
+        "priority": {"coding": [{"system": "http://terminology.hl7.org/CodeSystem/processpriority",
+                                 "code": "normal"}]},
+        "insurance": [{"sequence": 1, "focal": True,
+                       "coverage": {"display": "Commercial plan (OncoHealth UM)"}}],
+        "item": [{"sequence": 1, "productOrService": {"text": regimen_text}}],
+        "extension": [{"url": "https://mopa.demo/StructureDefinition/pa-evidence",
+                       "valueString": json.dumps(evidence)}],
+    }
+
+
+def build_claim_response(snapshot: dict, fhir_claim_id: str | None, decision: str,
+                         rationale: str, citations: list) -> dict:
+    """A ClaimResponse recording the reviewer's decision (complete/approved or complete/denied)."""
+    approved = decision.lower().startswith("approv")
+    resp = {
+        "resourceType": "ClaimResponse",
+        "status": "active",
+        "type": CLAIM_TYPE,
+        "use": "preauthorization",
+        "patient": _patient_ref(snapshot),
+        "created": _now(),
+        "insurer": {"display": "OncoHealth (delegated UM)"},
+        "outcome": "complete",
+        "disposition": (rationale or "")[:1000] or ("Approved" if approved else "Denied"),
+        "item": [{"itemSequence": 1, "adjudication": [{
+            "category": {"coding": [{
+                "system": "http://terminology.hl7.org/CodeSystem/adjudication",
+                "code": "eligible" if approved else "denied"}]}}]}],
+        "extension": [
+            {"url": "https://mopa.demo/StructureDefinition/pa-decision",
+             "valueString": "approved" if approved else "denied"},
+            {"url": "https://mopa.demo/StructureDefinition/pa-citations",
+             "valueString": json.dumps(citations or [])},
+        ],
+    }
+    if fhir_claim_id:
+        resp["request"] = {"reference": f"Claim/{fhir_claim_id}"}
+    return resp
+
+
+# ---------- write / read through PhenoML -> Medplum ----------------------
+def _try_create(client, provider, resource_type: str, resource: dict):
+    """Create a resource on the FHIR provider. Returns (id_or_None, error_or_None); never raises,
+    so a read-only instance degrades to a local-only record instead of failing the request."""
+    try:
+        resp = client.fhir.create(fhir_provider_id=provider, fhir_path=resource_type, request=resource)
+        return _created_id(resp), None
+    except Exception as e:
+        return None, f"{type(e).__name__}: {str(e)[:200]}"
+
+
+def submit_claim(client, provider, snapshot: dict) -> dict:
+    """Persist a preauthorization Claim (best-effort) and record it in the local registry. Returns
+    the queue record."""
+    local_id = uuid.uuid4().hex[:12]
+    claim = build_claim(snapshot, local_id)
+    fhir_id, err = _try_create(client, provider, "Claim", claim)
+    record = {
+        "id": local_id,
+        "fhir_claim_id": fhir_id,
+        "persisted": bool(fhir_id),
+        "persist_error": err,
+        "patient_name": patient_name(snapshot),
+        "patient_id": snapshot.get("patient_id"),
+        "regimen_text": claim["item"][0]["productOrService"]["text"],
+        "created": claim["created"],
+        "status": "queued",              # queued -> approved / denied
+        "decision": None,
+        "snapshot": snapshot,            # working data to rebuild the CDS envelope on review
+    }
+    reg = _load_registry()
+    reg["claims"][local_id] = record
+    _save_registry(reg)
+    return record
+
+
+def _light(record: dict) -> dict:
+    """A record without the heavy snapshot, for the queue list."""
+    return {k: v for k, v in record.items() if k != "snapshot"}
+
+
+def list_claims(client=None, provider=None) -> list:
+    """The payer queue: registry records (newest first), snapshot stripped. Reads are registry-backed
+    so the queue is stable even on a read-only FHIR instance; each record carries fhir_claim_id +
+    persisted so the UI can show whether it lives in Medplum."""
+    reg = _load_registry()
+    records = [_light(r) for r in reg["claims"].values()]
+    return sorted(records, key=lambda r: r.get("created", ""), reverse=True)
+
+
+def get_claim(local_id: str) -> dict | None:
+    return _load_registry()["claims"].get(local_id)
+
+
+def record_decision(client, provider, local_id: str, decision: str, rationale: str,
+                    citations: list, coverage_action: dict | None) -> dict:
+    """Write a ClaimResponse (+ Coverage on approve) for the claim and update the registry record."""
+    reg = _load_registry()
+    record = reg["claims"].get(local_id)
+    if not record:
+        raise KeyError(local_id)
+    snapshot = record["snapshot"]
+    cr = build_claim_response(snapshot, record.get("fhir_claim_id"), decision, rationale, citations)
+    cr_id, cr_err = _try_create(client, provider, "ClaimResponse", cr)
+
+    coverage_id = None
+    approved = decision.lower().startswith("approv")
+    if approved and coverage_action and coverage_action.get("resource"):
+        coverage_id, _ = _try_create(client, provider, "Coverage", coverage_action["resource"])
+
+    record["status"] = "approved" if approved else "denied"
+    record["decision"] = {"decision": "approved" if approved else "denied",
+                          "rationale": rationale, "citations": citations or [],
+                          "claim_response_id": cr_id, "claim_response_error": cr_err,
+                          "coverage_id": coverage_id, "decided_at": _now()}
+    reg["claims"][local_id] = record
+    _save_registry(reg)
+    return record

--- a/mopa-breast-pa/pa_fhir.py
+++ b/mopa-breast-pa/pa_fhir.py
@@ -193,6 +193,9 @@ def record_decision(client, provider, local_id: str, decision: str, rationale: s
     record = reg["claims"].get(local_id)
     if not record:
         raise KeyError(local_id)
+    if record.get("status") in ("approved", "denied"):
+        # Already decided: refuse to write a second ClaimResponse / overwrite the recorded outcome.
+        raise ValueError(f"claim already {record['status']}")
     snapshot = record["snapshot"]
     cr = build_claim_response(snapshot, record.get("fhir_claim_id"), decision, rationale, citations)
     cr_id, cr_err = _try_create(client, provider, "ClaimResponse", cr)

--- a/mopa-breast-pa/pipeline.py
+++ b/mopa-breast-pa/pipeline.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Return-based intake + readiness pipeline for the MOPA breast-cancer prior-auth demo.
+
+This is the single source of truth for the Layer 1 work that used to live inline in
+step1_intake.py and step1_5_readiness.py: pathology report -> mCODE FHIR (lang2fhir) -> validated
+codes with citations (construe) -> the TH RequestGroup -> IPS -> EHR write-back, plus assembling the
+resolved-HER2 Observation. Every function RETURNS data (no prints, no .state); the callers decide
+how to surface it:
+
+  - the CLI step scripts import these and keep their own banners/prints (course narrative),
+  - the web backend (ui_server.py) calls run_intake() / build_her2_observation() and serves JSON.
+
+The judgment side (DataRequirement gap-check, the UM-9 agent, the CDS Hooks envelope) is NOT here:
+cds_hooks_server/evaluate.py already owns it framework-free and both paths reuse it unchanged.
+"""
+import copy, json, uuid
+from pathlib import Path
+
+from common import as_dict, retry
+
+HERE = Path(__file__).resolve().parent
+LOINC, SNOMED = "http://loinc.org", "http://snomed.info/sct"
+
+# The documented, definitive mCODE elements we structure at intake. HER2 is deliberately absent:
+# it is equivocal (IHC 2+, ISH pending) in the report, so it is the gap the readiness step closes.
+# (spec = resource-profile, code system, code, display, source text, definitive value)
+CHART_SPECS = [
+    ("condition-encounter-diagnosis", SNOMED, "254837009", "Malignant neoplasm of breast",
+     "Invasive ductal carcinoma of the right breast, Nottingham histologic grade 2.", None),
+    ("observation-clinical-result", LOINC, "21908-9", "Stage group.clinical Cancer",
+     "Cancer clinical stage group: Stage IIB (T2 N1 M0), AJCC 8th edition.", "Stage IIB"),
+    ("observation-lab", LOINC, "85337-4",
+     "Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain",
+     "Estrogen receptor (ER) status by immunohistochemistry: negative, 0% nuclear staining.",
+     "Negative 0%"),
+    ("observation-lab", LOINC, "85339-0",
+     "Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain",
+     "Progesterone receptor (PR) status by immunohistochemistry: negative, 0% nuclear staining.",
+     "Negative 0%"),
+    ("observation-clinical-result", LOINC, "89247-1", "ECOG performance status",
+     "ECOG performance status: 0 (fully active).", "0 (fully active)"),
+]
+
+# Construe validates codes WITH citations (the exact text spans justifying each code). Guarded per
+# system: an instance may not enable every code system, and a missing one must not abort intake.
+CONSTRUE_JOBS = {
+    "rxnorm": ("RXNORM", "Paclitaxel intravenous; trastuzumab intravenous."),
+    "loinc": ("LOINC", "HER2 receptor status; estrogen receptor status; progesterone receptor "
+                       "status in breast cancer specimen by immunohistochemistry."),
+    "snomed": ("SNOMED_CT_US_LITE", "Invasive ductal carcinoma of breast; clinical stage IIB."),
+}
+
+
+# ---------- FHIR bundle helpers (moved here from step1_intake) ------------
+def _entry(resource: dict) -> dict:
+    """Wrap a resource as a FHIR transaction entry with a fresh bundle-local fullUrl."""
+    return {"fullUrl": f"urn:uuid:{uuid.uuid4()}", "resource": resource,
+            "request": {"method": "POST", "url": resource["resourceType"]}}
+
+
+def _lang2fhir(client, resource, text, patient_full_url):
+    """lang2fhir.create one resource from natural-language text, then repoint its subject at the
+    patient's bundle-local fullUrl (lang2fhir stamps a placeholder subject; overwrite it)."""
+    r = as_dict(retry(client.lang2fhir.create, label=f"lang2fhir.{resource}",
+                      version="R4", resource=resource, text=text))
+    r["subject"] = {"reference": patient_full_url}
+    return r
+
+
+def _stamp(resource, system, code, display, value=None):
+    """Normalize a lang2fhir resource onto the identifying code (and a definitive value) the payer's
+    DataRequirement keys on, so the downstream gap-check is deterministic (PhenoML's Layer 1 job)."""
+    cc = resource.setdefault("code", {})
+    codings = cc.setdefault("coding", [])
+    if not any(c.get("system") == system and c.get("code") == code for c in codings):
+        codings.append({"system": system, "code": code, "display": display})
+    cc.setdefault("text", display)
+    if value is not None:
+        vcc = resource.get("valueCodeableConcept") or {}
+        vcc["text"] = value
+        resource["valueCodeableConcept"] = vcc
+    return resource
+
+
+# ---------- fine-grained intake steps (each RETURNS data) -----------------
+def extract_bundle(client, report_text: str):
+    """Pathology report -> FHIR transaction Bundle (lang2fhir.create_multi). Returns (bundle, resources)."""
+    multi = retry(client.lang2fhir.create_multi, label="create_multi", text=report_text, version="R4")
+    return as_dict(multi.bundle), as_dict(multi.resources)
+
+
+def patient_full_url(bundle: dict) -> str:
+    """The single Patient's bundle-local fullUrl. Raises ValueError if not exactly one (the IPS +
+    EHR steps assume a single patient)."""
+    patients = [e for e in bundle.get("entry", [])
+                if e.get("resource", {}).get("resourceType") == "Patient"]
+    if len(patients) != 1:
+        raise ValueError(f"expected exactly 1 Patient in the bundle, found {len(patients)}")
+    return patients[0]["fullUrl"]
+
+
+def structure_chart(client, patient_url: str) -> list:
+    """Structure the documented mCODE evidence elements as FHIR transaction entries (diagnosis,
+    stage, ER, PR, ECOG). Deliberately omits HER2 (the gap). Returns a list of transaction entries."""
+    entries = []
+    for res, system, code, display, text, value in CHART_SPECS:
+        r = _stamp(_lang2fhir(client, res, text, patient_url), system, code, display, value)
+        entries.append(_entry(r))
+    return entries
+
+
+def validate_codes(client) -> dict:
+    """Validate codes with citations (construe.codes.extract). Returns {system_key: [code dicts]};
+    a code system the instance does not enable comes back as an empty list, never an exception."""
+    from phenoml.construe import ExtractRequestSystem
+    out = {}
+    for key, (system, text) in CONSTRUE_JOBS.items():
+        try:
+            res = retry(client.construe.codes.extract, label=f"construe.{key}",
+                        text=text, system=ExtractRequestSystem(name=system))
+            out[key] = [as_dict(c) for c in (res.codes or [])]
+        except Exception as e:
+            out[key] = []
+            out.setdefault("_errors", {})[key] = f"{type(e).__name__}: {str(e)[:120]}"
+    return out
+
+
+def assemble_regimen(client, patient_url: str):
+    """The TH regimen as a RequestGroup binding two component-drug MedicationRequests. lang2fhir
+    emits the drugs; the RequestGroup is hand-assembled from regimen_th.json (it is the unit of
+    authorization). Returns (regimen dict, [rg_entry, pac_entry, tra_entry])."""
+    paclitaxel = _lang2fhir(client, "medicationrequest",
+        "Paclitaxel 80 mg/m2 intravenous, weekly, adjuvant therapy for breast cancer.", patient_url)
+    trastuzumab = _lang2fhir(client, "medicationrequest",
+        "Trastuzumab intravenous, weekly, HER2-targeted adjuvant therapy for breast cancer.", patient_url)
+    pac_entry, tra_entry = _entry(paclitaxel), _entry(trastuzumab)
+
+    regimen = json.loads((HERE / "regimen_th.json").read_text())
+    regimen["subject"] = {"reference": patient_url}
+    regimen["action"][0]["resource"] = {"reference": pac_entry["fullUrl"]}
+    regimen["action"][1]["resource"] = {"reference": tra_entry["fullUrl"]}
+    rg_entry = _entry(regimen)
+    return regimen, [rg_entry, pac_entry, tra_entry]
+
+
+def make_ips(client, bundle: dict) -> str:
+    """International Patient Summary narrative (summary.create mode=ips)."""
+    ips = retry(client.summary.create, label="summary.create", fhir_resources=bundle, mode="ips")
+    return ips.summary or ""
+
+
+def persist_chart(client, provider: str, bundle: dict, chart_resources: list, draft_order_entries: list):
+    """Fold the Patient + structured evidence + drugs + RequestGroup into ONE transaction and write
+    it (fhir.execute_bundle). Returns {"patient_id": str|None, "locations": [...], "ok": bool,
+    "error": str|None}. Writing needs a dedicated instance; a read-only instance is reported, not
+    raised, so the rest of the pipeline still runs on the in-memory chart."""
+    tx_bundle = copy.deepcopy(bundle)
+    tx_bundle["entry"].extend(chart_resources + draft_order_entries)
+    try:
+        resp = as_dict(client.fhir.execute_bundle(fhir_provider_id=provider, request=tx_bundle))
+    except Exception as e:
+        return {"patient_id": None, "locations": [], "ok": False,
+                "error": f"{type(e).__name__}: {str(e)[:300]}"}
+    locations, patient_id = [], None
+    for e in resp.get("entry", []) or []:
+        loc = (e.get("response") or {}).get("location") or ""
+        if loc:
+            locations.append(loc)
+        if "Patient/" in loc and patient_id is None:
+            patient_id = loc.split("Patient/")[1].split("/")[0]
+    return {"patient_id": patient_id, "locations": locations, "ok": True, "error": None}
+
+
+# ---------- readiness: assemble the resolved-HER2 Observation -------------
+def build_her2_observation(client, her2_text: str, patient_url: str, positive: bool = True) -> dict:
+    """Structure a resolved HER2 result as an observation-lab (lang2fhir), stamped onto the canonical
+    HER2 LOINC with a definitive value so it satisfies the HER2 DataRequirement. Returns a
+    transaction entry ({fullUrl, resource, request})."""
+    obs = as_dict(retry(client.lang2fhir.create, label="lang2fhir.her2",
+                        version="R4", resource="observation-lab", text=her2_text))
+    obs["subject"] = {"reference": patient_url}
+    obs.setdefault("code", {}).setdefault("coding", []).append(
+        {"system": LOINC, "code": "85319-2",
+         "display": "HER2 [Presence] in Breast cancer specimen by Immune stain"})
+    obs["code"].setdefault("text", "HER2 [Presence] in Breast cancer specimen by Immune stain")
+    obs["valueCodeableConcept"] = {"text": "Positive (HER2 amplified)" if positive
+                                    else "Negative (HER2 not amplified)"}
+    return {"fullUrl": f"urn:uuid:{uuid.uuid4()}", "resource": obs,
+            "request": {"method": "POST", "url": "Observation"}}
+
+
+# ---------- high-level composer (what the web backend calls) --------------
+def run_intake(client, provider: str, report_text: str) -> dict:
+    """Compose the full intake in one call and return every artifact the demo needs downstream:
+    bundle, resources, chart_resources, patient_full_url, construe_codes, regimen_requestgroup,
+    draft_order_entries, ips_text, and the EHR write result. The CLI step scripts call the
+    fine-grained functions above so they can print between sub-steps; the server calls this."""
+    bundle, resources = extract_bundle(client, report_text)
+    p_url = patient_full_url(bundle)
+    chart_resources = structure_chart(client, p_url)
+    construe_codes = validate_codes(client)
+    regimen, draft_order_entries = assemble_regimen(client, p_url)
+    ips_text = make_ips(client, bundle)
+    write = persist_chart(client, provider, bundle, chart_resources, draft_order_entries)
+    return {
+        "path_report_text": report_text,
+        "bundle": bundle,
+        "resources": resources,
+        "patient_full_url": p_url,
+        "chart_resources": chart_resources,
+        "construe_codes": construe_codes,
+        "regimen_requestgroup": regimen,
+        "draft_order_entries": draft_order_entries,
+        "ips_text": ips_text,
+        "patient_id": write["patient_id"],
+        "write": write,
+    }

--- a/mopa-breast-pa/step1_5_readiness.py
+++ b/mopa-breast-pa/step1_5_readiness.py
@@ -9,12 +9,11 @@ fill them, then hand a clean payload to the Layer 2 CDS Hooks exchange (Step 2).
 
 Run:  .venv/bin/python step1_5_readiness.py        (run step1_intake.py first)
 """
-import uuid
-
-from common import (HERE, load_env, make_client, resolve_provider, as_dict, parse_json,
+from common import (load_env, make_client, resolve_provider, as_dict, parse_json,
                     banner, retry, cleanup, load_state, save_state, require, reset_state,
                     fresh_requested)
 from cds_hooks_server import evaluate
+import pipeline
 
 
 def _chart_resources(state, extra=None):
@@ -70,18 +69,12 @@ def run(client, env, provider, state, created):
     collected_her2 = ("HER2 status by reflex in-situ hybridization (ISH): POSITIVE (HER2 gene "
                       "amplified). Resolves the earlier equivocal IHC 2+ result.")
     state["collected_her2"] = collected_her2
-    her2_obs = as_dict(retry(client.lang2fhir.create, label="lang2fhir.her2",
-                             version="R4", resource="observation-lab", text=collected_her2))
-    her2_obs["subject"] = {"reference": state["patient_full_url"]}
-    # Stamp the canonical HER2 LOINC + a definitive positive value so the resolved observation
-    # satisfies the HER2 DataRequirement (matched by code) and reads as positive downstream.
-    her2_obs.setdefault("code", {}).setdefault("coding", []).append(
-        {"system": "http://loinc.org", "code": "85319-2",
-         "display": "HER2 [Presence] in Breast cancer specimen by Immune stain"})
-    her2_obs["code"].setdefault("text", "HER2 [Presence] in Breast cancer specimen by Immune stain")
-    her2_obs["valueCodeableConcept"] = {"text": "Positive (HER2 amplified)"}
-    her2_entry = {"fullUrl": f"urn:uuid:{uuid.uuid4()}", "resource": her2_obs,
-                  "request": {"method": "POST", "url": "Observation"}}
+    # pipeline.build_her2_observation structures the resolved result via lang2fhir and stamps the
+    # canonical HER2 LOINC + a definitive positive value, so it satisfies the HER2 DataRequirement
+    # (matched by code) and reads as positive downstream.
+    her2_entry = pipeline.build_her2_observation(client, collected_her2, state["patient_full_url"],
+                                                 positive=True)
+    her2_obs = her2_entry["resource"]
     state["her2_entry"] = her2_entry
 
     her2_writeback_ok = False

--- a/mopa-breast-pa/step1_intake.py
+++ b/mopa-breast-pa/step1_intake.py
@@ -9,187 +9,92 @@ chart, the regimen, the codes, the IPS, and the patient id to the readiness step
 The deliberate gap: the path report documents diagnosis, stage, and ER/PR, but HER2 is equivocal
 (IHC 2+, ISH pending), so no definitive HER2 is structured here. Step 1.5 detects and collects it.
 
+The extraction/structuring/write logic lives in pipeline.py (shared with the web backend); this
+script keeps the banners and printed narrative so it still reads top-to-bottom as a course.
+
 Run:  .venv/bin/python step1_intake.py        (then step1_5_readiness.py, step2_cdshooks.py, ...)
 """
-import copy, json, sys, uuid
-
-from common import (HERE, load_env, make_client, resolve_provider, as_dict, parse_json,
-                    banner, retry, cleanup, load_state, save_state, reset_state, fresh_requested)
-
-
-def _entry(resource: dict) -> dict:
-    """Wrap a resource as a FHIR transaction entry with a fresh bundle-local fullUrl."""
-    return {"fullUrl": f"urn:uuid:{uuid.uuid4()}", "resource": resource,
-            "request": {"method": "POST", "url": resource["resourceType"]}}
-
-
-def _lang2fhir(client, resource, text, patient_full_url):
-    """lang2fhir.create one resource from natural-language text, then repoint its subject at the
-    patient's bundle-local fullUrl. lang2fhir stamps a placeholder subject; a plain setdefault
-    would no-op (the key already exists), leaving the resource orphaned, so we overwrite it."""
-    r = as_dict(retry(client.lang2fhir.create, label=f"lang2fhir.{resource}",
-                      version="R4", resource=resource, text=text))
-    r["subject"] = {"reference": patient_full_url}
-    return r
-
-
-def _stamp(resource, system, code, display, value=None):
-    """Normalize a lang2fhir resource onto the identifying code (and a definitive value) the payer's
-    DataRequirement keys on. lang2fhir codes from free text, so the exact LOINC/SNOMED it picks can
-    differ from the Library's; stamping the canonical code is part of PhenoML's Layer 1 job (make the
-    chart conform to the payer's required data) and makes the gap-check deterministic."""
-    cc = resource.setdefault("code", {})
-    codings = cc.setdefault("coding", [])
-    if not any(c.get("system") == system and c.get("code") == code for c in codings):
-        codings.append({"system": system, "code": code, "display": display})
-    cc.setdefault("text", display)
-    if value is not None:
-        vcc = resource.get("valueCodeableConcept") or {}
-        vcc["text"] = value
-        resource["valueCodeableConcept"] = vcc
-    return resource
+from common import (load_env, make_client, resolve_provider, banner,
+                    cleanup, load_state, save_state, reset_state, fresh_requested)
+import pipeline
 
 
 def run(client, env, provider, state, created):
     # --- Step 1.1: pathology report -> FHIR bundle (lang2fhir.create_multi) ----
     banner("STEP 1.1  Pathology report -> FHIR bundle (lang2fhir.create_multi)")
-    report = (HERE / "sample_path_report.txt").read_text()
+    report = (pipeline.HERE / "sample_path_report.txt").read_text()
     state["path_report_text"] = report
     if state.get("bundle") and state.get("chart_resources") is not None:
         print("(reusing cached chart from .state/ - re-run with --fresh to re-extract)")
         bundle = state["bundle"]
     else:
-        multi = retry(client.lang2fhir.create_multi, label="create_multi", text=report, version="R4")
-        bundle, extracted = as_dict(multi.bundle), as_dict(multi.resources)
+        bundle, extracted = pipeline.extract_bundle(client, report)
         state["bundle"], state["resources"] = bundle, extracted
         print(f"extracted {len(bundle.get('entry', []))} resources:")
         for r in extracted or []:
             print(f"  - {r.get('resourceType')}: {r.get('description')}")
 
-    patients = [e["resource"] for e in bundle.get("entry", [])
-                if e.get("resource", {}).get("resourceType") == "Patient"]
-    if len(patients) != 1:
-        sys.exit(f"expected exactly 1 Patient in the bundle, found {len(patients)}; the IPS + EHR "
-                 "steps assume a single patient. Re-run with --fresh to re-extract.")
-    patient_full_url = next(e["fullUrl"] for e in bundle["entry"]
-                            if e["resource"]["resourceType"] == "Patient")
-    state["patient_full_url"] = patient_full_url
+    p_url = pipeline.patient_full_url(bundle)  # raises if not exactly one Patient
+    state["patient_full_url"] = p_url
 
     # --- Step 1.2: structure the documented mCODE elements (lang2fhir.create) --
     banner("STEP 1.2  Structure the mCODE evidence elements (lang2fhir.create)")
     # We feed the *elements* of the IG's oncology profiles to lang2fhir as natural language and let
     # it return conformant base resources. We deliberately structure ONLY the documented, definitive
-    # facts: diagnosis, stage, ER, PR, ECOG. HER2 is equivocal (IHC 2+, ISH pending) in the report,
-    # so there is NO definitive HER2 element here - that is the gap the readiness step must close.
-    # (Authoring the real OncologyLineOfTherapy / tumor-marker StructureDefinitions via
-    # upload_profile is deferred; see the README.)
-    LOINC, SNOMED = "http://loinc.org", "http://snomed.info/sct"
-    chart_specs = [
-        ("condition-encounter-diagnosis", SNOMED, "254837009", "Malignant neoplasm of breast",
-         "Invasive ductal carcinoma of the right breast, Nottingham histologic grade 2.", None),
-        ("observation-clinical-result", LOINC, "21908-9", "Stage group.clinical Cancer",
-         "Cancer clinical stage group: Stage IIB (T2 N1 M0), AJCC 8th edition.", "Stage IIB"),
-        ("observation-lab", LOINC, "85337-4",
-         "Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain",
-         "Estrogen receptor (ER) status by immunohistochemistry: negative, 0% nuclear staining.",
-         "Negative 0%"),
-        ("observation-lab", LOINC, "85339-0",
-         "Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain",
-         "Progesterone receptor (PR) status by immunohistochemistry: negative, 0% nuclear staining.",
-         "Negative 0%"),
-        ("observation-clinical-result", LOINC, "89247-1", "ECOG performance status",
-         "ECOG performance status: 0 (fully active).", "0 (fully active)"),
-    ]
-    chart_resources = []
-    for res, system, code, display, text, value in chart_specs:
-        r = _stamp(_lang2fhir(client, res, text, patient_full_url), system, code, display, value)
-        chart_resources.append(_entry(r))
-        print(f"  + {r.get('resourceType')}: {r.get('code', {}).get('text')}")
+    # facts: diagnosis, stage, ER, PR, ECOG. HER2 is equivocal (IHC 2+, ISH pending), so there is NO
+    # definitive HER2 element here - that is the gap the readiness step must close.
+    chart_resources = pipeline.structure_chart(client, p_url)
     state["chart_resources"] = chart_resources
+    for e in chart_resources:
+        r = e["resource"]
+        print(f"  + {r.get('resourceType')}: {r.get('code', {}).get('text')}")
 
     # --- Step 1.3: validate codes with citations (construe.codes.extract) ------
     banner("STEP 1.3  Validate codes with citations (construe.codes.extract)")
-    from phenoml.construe import ExtractRequestSystem
-    # Construe returns codes with CITATIONS (the exact text spans that justify each code). We
-    # validate three systems: RxNorm for the drugs, LOINC for the tumor-marker tests, SNOMED for
-    # the stage/diagnosis. Each call is guarded: an instance may not enable every code system, and
-    # a missing system must not abort intake.
-    construe_jobs = {
-        "rxnorm": ("RXNORM", "Paclitaxel intravenous; trastuzumab intravenous."),
-        "loinc": ("LOINC", "HER2 receptor status; estrogen receptor status; progesterone receptor "
-                            "status in breast cancer specimen by immunohistochemistry."),
-        "snomed": ("SNOMED_CT_US_LITE", "Invasive ductal carcinoma of breast; clinical stage IIB."),
-    }
-    construe_codes = {}
-    for key, (system, text) in construe_jobs.items():
-        try:
-            res = retry(client.construe.codes.extract, label=f"construe.{key}",
-                        text=text, system=ExtractRequestSystem(name=system))
-            codes = [as_dict(c) for c in (res.codes or [])]
-        except Exception as e:
-            codes = []
-            print(f"  construe {system} skipped: {type(e).__name__}: {str(e)[:120]}")
-        construe_codes[key] = codes
-        for c in codes:
+    construe_codes = pipeline.validate_codes(client)
+    state["construe_codes"] = construe_codes
+    for key, (system, _text) in pipeline.CONSTRUE_JOBS.items():
+        err = (construe_codes.get("_errors") or {}).get(key)
+        if err:
+            print(f"  construe {system} skipped: {err}")
+            continue
+        for c in construe_codes.get(key, []):
             cites = c.get("citations") or []
             cite = f'  cite="{(cites[0] or {}).get("text", "")}"' if cites else ""
             print(f"  [{system}] {c.get('code')} - {c.get('description')}{cite}")
-    state["construe_codes"] = construe_codes
 
     # --- Step 1.4: assemble the regimen as a RequestGroup ---------------------
     banner("STEP 1.4  Assemble the regimen RequestGroup (TH = paclitaxel + trastuzumab)")
-    # The component drugs come from lang2fhir (resource='medicationrequest'); the RequestGroup that
-    # binds them into one orderable regimen is NOT something lang2fhir emits, so we hand-assemble it
-    # from regimen_th.json. The regimen, not a single drug, is the unit of authorization: its
-    # action[] references the two MedicationRequest fullUrls, and its extensions carry the regimen
-    # intent (adjuvant), the line of therapy (1L), and the disease context (breast).
-    paclitaxel = _lang2fhir(client, "medicationrequest",
-        "Paclitaxel 80 mg/m2 intravenous, weekly, adjuvant therapy for breast cancer.", patient_full_url)
-    trastuzumab = _lang2fhir(client, "medicationrequest",
-        "Trastuzumab intravenous, weekly, HER2-targeted adjuvant therapy for breast cancer.", patient_full_url)
-    pac_entry, tra_entry = _entry(paclitaxel), _entry(trastuzumab)
-
-    regimen = json.loads((HERE / "regimen_th.json").read_text())
-    regimen["subject"] = {"reference": patient_full_url}
-    regimen["action"][0]["resource"] = {"reference": pac_entry["fullUrl"]}
-    regimen["action"][1]["resource"] = {"reference": tra_entry["fullUrl"]}
-    rg_entry = _entry(regimen)
+    # The component drugs come from lang2fhir; the RequestGroup that binds them into one orderable
+    # regimen is hand-assembled from regimen_th.json. The regimen, not a single drug, is the unit of
+    # authorization: its action[] references the two MedicationRequest fullUrls, and its extensions
+    # carry the regimen intent (adjuvant), the line of therapy (1L), and the disease context (breast).
+    regimen, draft_order_entries = pipeline.assemble_regimen(client, p_url)
     state["regimen_requestgroup"] = regimen
-    # The draft orders the prescriber would carry into the CDS Hooks exchange (Step 2): the regimen
-    # plus its component drugs.
-    state["draft_order_entries"] = [rg_entry, pac_entry, tra_entry]
-    print(f"  RequestGroup {rg_entry['fullUrl']} -> action: paclitaxel, trastuzumab")
+    state["draft_order_entries"] = draft_order_entries
+    print(f"  RequestGroup {draft_order_entries[0]['fullUrl']} -> action: paclitaxel, trastuzumab")
     print(f"  extensions: regimen-intent (adjuvant), treatment-line (1L), disease-context (breast)")
 
     # --- Step 1.5: International Patient Summary (summary.create mode=ips) ------
     banner("STEP 1.5  International Patient Summary (summary.create mode=ips)")
-    ips = retry(client.summary.create, label="summary.create", fhir_resources=bundle, mode="ips")
-    ips_text = ips.summary or ""
+    ips_text = pipeline.make_ips(client, bundle)
     state["ips_text"] = ips_text
     print(ips_text[:1500])
 
     # --- Step 1.6: persist the full chart + regimen in ONE transaction ---------
     banner("STEP 1.6  Persist the chart + regimen (fhir.execute_bundle)")
-    # Fold the Patient (from create_multi), the structured mCODE evidence, the two component drugs,
-    # and the RequestGroup into one transaction. A single execute_bundle persists them interlinked;
-    # the server assigns real ids and rewrites the urn:uuid references. (create_multi only EXTRACTS;
-    # execute_bundle is what writes.) Writing needs a dedicated instance; on a shared/experiment
-    # instance this logs a read-only notice and the rest of the pipeline still runs on the in-memory
-    # chart.
-    tx_bundle = copy.deepcopy(bundle)
-    tx_bundle["entry"].extend(chart_resources + state["draft_order_entries"])
-    patient_id = None
-    try:
-        resp = as_dict(client.fhir.execute_bundle(fhir_provider_id=provider, request=tx_bundle))
-        for e in resp.get("entry", []) or []:
-            loc = (e.get("response") or {}).get("location") or ""
-            print(f"  created {loc}")
-            if "Patient/" in loc and patient_id is None:
-                patient_id = loc.split("Patient/")[1].split("/")[0]
-        print(f"persisted {len(resp.get('entry', []) or [])} resources; Patient/{patient_id}")
-    except Exception as e:
-        print("execute_bundle failed (instance may be read-only):", type(e).__name__, str(e)[:300])
-    state["patient_id"] = patient_id
+    # A single execute_bundle persists the Patient, structured evidence, drugs, and RequestGroup
+    # interlinked; the server assigns real ids and rewrites the urn:uuid references. Writing needs a
+    # dedicated instance; on a read-only instance this logs a notice and the pipeline continues on
+    # the in-memory chart.
+    write = pipeline.persist_chart(client, provider, bundle, chart_resources, draft_order_entries)
+    for loc in write["locations"]:
+        print(f"  created {loc}")
+    if write["ok"]:
+        print(f"persisted {len(write['locations'])} resources; Patient/{write['patient_id']}")
+    else:
+        print("execute_bundle failed (instance may be read-only):", write["error"])
+    state["patient_id"] = write["patient_id"]
 
 
 if __name__ == "__main__":

--- a/mopa-breast-pa/step1_intake.py
+++ b/mopa-breast-pa/step1_intake.py
@@ -14,6 +14,8 @@ script keeps the banners and printed narrative so it still reads top-to-bottom a
 
 Run:  .venv/bin/python step1_intake.py        (then step1_5_readiness.py, step2_cdshooks.py, ...)
 """
+import sys
+
 from common import (load_env, make_client, resolve_provider, banner,
                     cleanup, load_state, save_state, reset_state, fresh_requested)
 import pipeline
@@ -34,7 +36,10 @@ def run(client, env, provider, state, created):
         for r in extracted or []:
             print(f"  - {r.get('resourceType')}: {r.get('description')}")
 
-    p_url = pipeline.patient_full_url(bundle)  # raises if not exactly one Patient
+    try:
+        p_url = pipeline.patient_full_url(bundle)  # raises if not exactly one Patient
+    except ValueError as e:
+        sys.exit(f"{e}; the IPS + EHR steps assume a single patient. Re-run with --fresh to re-extract.")
     state["patient_full_url"] = p_url
 
     # --- Step 1.2: structure the documented mCODE elements (lang2fhir.create) --

--- a/mopa-breast-pa/ui/index.html
+++ b/mopa-breast-pa/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MOPA Prior-Auth Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/mopa-breast-pa/ui/package-lock.json
+++ b/mopa-breast-pa/ui/package-lock.json
@@ -1,0 +1,2239 @@
+{
+  "name": "mopa-prior-auth-ui",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mopa-prior-auth-ui",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mantine/core": "^8.2.4",
+        "@mantine/hooks": "^8.2.4",
+        "@tabler/icons-react": "^3.34.1",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "@vitejs/plugin-react": "5.0.0",
+        "typescript": "^5.6.0",
+        "vite": "7.1.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mantine/core": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.18.tgz",
+      "integrity": "sha512-9tph1lTVogKPjTx02eUxDUOdXacPzK62UuSqb4TdGliI54/Xgxftq0Dfqu6XuhCxn9J5MDJaNiLDvL/1KRkYqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "clsx": "^2.1.1",
+        "react-number-format": "^5.4.4",
+        "react-remove-scroll": "^2.7.1",
+        "react-textarea-autosize": "8.5.9",
+        "type-fest": "^4.41.0"
+      },
+      "peerDependencies": {
+        "@mantine/hooks": "8.3.18",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/hooks": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.18.tgz",
+      "integrity": "sha512-QoWr9+S8gg5050TQ06aTSxtlpGjYOpIllRbjYYXlRvZeTsUqiTbVfvQROLexu4rEaK+yy9Wwriwl9PMRgbLqPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.30.tgz",
+      "integrity": "sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
+      "integrity": "sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.44.0.tgz",
+      "integrity": "sha512-8+rvzBbVm/1Z3sG3x7GUNAaxIKxwgz8xaMhRs23nrCnMTKRFAhEC+82zAIFeAA0seXdrAGX5HFCkaLpGK2rVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": "3.44.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.0.tgz",
+      "integrity": "sha512-Jx9JfsTa05bYkS9xo0hkofp2dCmp1blrKjw9JONs5BTHOvJCgLbaPSuZLGSVJW6u2qe0tc4eevY0+gSNNi0YCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.30",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-number-format": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.5.tgz",
+      "integrity": "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.1.tgz",
+      "integrity": "sha512-yJ+Mp7OyV+4S+afWo+QyoL9jFWD11QFH0i5i7JypnfTcA1rmgxCbiA8WwAICDEtZ1Z1hzrVhN8R8rGTqkTY8ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.6",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.14"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/mopa-breast-pa/ui/package.json
+++ b/mopa-breast-pa/ui/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mopa-prior-auth-ui",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Provider + Payer prior-auth UI for the MOPA breast-cancer demo",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@mantine/core": "^8.2.4",
+    "@mantine/hooks": "^8.2.4",
+    "@tabler/icons-react": "^3.34.1",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "5.0.0",
+    "typescript": "^5.6.0",
+    "vite": "7.1.1"
+  }
+}

--- a/mopa-breast-pa/ui/src/App.tsx
+++ b/mopa-breast-pa/ui/src/App.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import {
+  AppShell, Group, Title, Tabs, Alert, Badge, Container, Text,
+} from "@mantine/core";
+import { IconStethoscope, IconShieldCheck, IconAlertTriangle } from "@tabler/icons-react";
+import { api } from "./api";
+import { ProviderView } from "./ProviderView";
+import { PayerView } from "./PayerView";
+
+export function App() {
+  const [tab, setTab] = useState<string>("provider");
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [provider, setProvider] = useState<string | null>(null);
+  const [queueBump, setQueueBump] = useState(0); // incremented on submit to refresh the payer queue
+
+  useEffect(() => {
+    api.health().then((h) => { setConfigured(h.configured); setProvider(h.provider); })
+      .catch(() => setConfigured(false));
+  }, []);
+
+  return (
+    <AppShell header={{ height: 60 }} padding="md">
+      <AppShell.Header>
+        <Group h="100%" px="md" justify="space-between">
+          <Group gap="xs">
+            <Title order={4}>MOPA Prior-Auth</Title>
+            <Text c="dimmed" size="sm">breast-cancer oncology · OncoHealth UM-9 · Medplum EHR</Text>
+          </Group>
+          {configured === true && <Badge color="teal" variant="light">PhenoML connected</Badge>}
+          {configured === false && <Badge color="red" variant="light">not configured</Badge>}
+        </Group>
+      </AppShell.Header>
+
+      <AppShell.Main>
+        <Container size="lg">
+          {configured === false && (
+            <Alert color="orange" icon={<IconAlertTriangle size={18} />} mb="md"
+              title="Backend not connected to PhenoML">
+              Set <code>PHENOML_CLIENT_ID</code>, <code>PHENOML_CLIENT_SECRET</code> and{" "}
+              <code>PHENOML_FHIR_PROVIDER_ID</code>, then restart <code>ui_server.py</code>.
+            </Alert>
+          )}
+
+          <Tabs value={tab} onChange={(v) => setTab(v || "provider")}>
+            <Tabs.List mb="md">
+              <Tabs.Tab value="provider" leftSection={<IconStethoscope size={16} />}>
+                Provider — submit
+              </Tabs.Tab>
+              <Tabs.Tab value="payer" leftSection={<IconShieldCheck size={16} />}>
+                Payer — review
+              </Tabs.Tab>
+            </Tabs.List>
+
+            <Tabs.Panel value="provider">
+              <ProviderView
+                onSubmitted={() => { setQueueBump((n) => n + 1); setTab("payer"); }}
+              />
+            </Tabs.Panel>
+            <Tabs.Panel value="payer">
+              <PayerView refreshKey={queueBump} />
+            </Tabs.Panel>
+          </Tabs>
+
+          {provider && (
+            <Text c="dimmed" size="xs" mt="xl">FHIR provider: {provider}</Text>
+          )}
+        </Container>
+      </AppShell.Main>
+    </AppShell>
+  );
+}

--- a/mopa-breast-pa/ui/src/PayerView.tsx
+++ b/mopa-breast-pa/ui/src/PayerView.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Card, Table, Badge, Button, Group, Stack, Text, Loader, Alert, Grid, Title,
+  SegmentedControl, Textarea, Divider, Anchor,
+} from "@mantine/core";
+import { IconRefresh, IconGavel, IconThumbUp, IconThumbDown, IconRobot } from "@tabler/icons-react";
+import { api, type ClaimRecord, type ClaimDetail, type Recommendation } from "./api";
+import { ReadinessPanel, EvidencePanel } from "./components";
+
+const STATUS_COLOR: Record<string, string> = { queued: "blue", approved: "teal", denied: "red" };
+const INDICATOR_COLOR: Record<string, string> = { info: "teal", warning: "orange", critical: "red" };
+
+export function PayerView({ refreshKey }: { refreshKey: number }) {
+  const [claims, setClaims] = useState<ClaimRecord[]>([]);
+  const [sel, setSel] = useState<string | null>(null);
+  const [detail, setDetail] = useState<ClaimDetail | null>(null);
+  const [rec, setRec] = useState<Recommendation | null>(null);
+  const [her2, setHer2] = useState("resolved");
+  const [note, setNote] = useState("");
+  const [loadingList, setLoadingList] = useState(false);
+  const [loadingRec, setLoadingRec] = useState(false);
+  const [deciding, setDeciding] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const loadList = useCallback(() => {
+    setLoadingList(true);
+    api.claims().then((r) => setClaims(r.claims)).catch((e) => setErr(e.message))
+      .finally(() => setLoadingList(false));
+  }, []);
+
+  useEffect(() => { loadList(); }, [loadList, refreshKey]);
+
+  async function open(id: string) {
+    setSel(id); setDetail(null); setRec(null); setNote(""); setHer2("resolved"); setErr(null);
+    try { setDetail(await api.claim(id)); } catch (e: any) { setErr(e.message); }
+  }
+
+  async function recommend() {
+    if (!sel) return;
+    setLoadingRec(true); setErr(null); setRec(null);
+    try {
+      const r = await api.recommend(sel, her2 === "resolved" ? null : her2);
+      setRec(r);
+      setNote(r.card?.detail || "");
+    } catch (e: any) { setErr(e.message); }
+    finally { setLoadingRec(false); }
+  }
+
+  async function decide(decision: "approve" | "deny") {
+    if (!sel) return;
+    setDeciding(true); setErr(null);
+    try {
+      await api.decide(sel, decision, note, [], decision === "approve" ? rec?.coverage : null);
+      await open(sel);
+      loadList();
+    } catch (e: any) { setErr(e.message); }
+    finally { setDeciding(false); }
+  }
+
+  return (
+    <Grid>
+      <Grid.Col span={{ base: 12, md: 4 }}>
+        <Card withBorder radius="md" padding="md">
+          <Group justify="space-between" mb="xs">
+            <Text fw={600}>Review queue</Text>
+            <Button size="xs" variant="light" leftSection={<IconRefresh size={14} />}
+              onClick={loadList} loading={loadingList}>Refresh</Button>
+          </Group>
+          {claims.length === 0 && <Text size="sm" c="dimmed">No submissions yet.</Text>}
+          <Table highlightOnHover verticalSpacing={6}>
+            <Table.Tbody>
+              {claims.map((c) => (
+                <Table.Tr key={c.id} onClick={() => open(c.id)}
+                  style={{ cursor: "pointer", background: sel === c.id ? "var(--mantine-color-blue-0)" : undefined }}>
+                  <Table.Td>
+                    <Text fw={500}>{c.patient_name}</Text>
+                    <Text size="xs" c="dimmed">{c.regimen_text}</Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge color={STATUS_COLOR[c.status]} variant="light">{c.status}</Badge>
+                    {!c.persisted && <Text size="10px" c="dimmed">local only</Text>}
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Card>
+      </Grid.Col>
+
+      <Grid.Col span={{ base: 12, md: 8 }}>
+        {err && <Alert color="red" title="Error" mb="md">{err}</Alert>}
+        {!sel && <Text c="dimmed">Select a submission from the queue to review it.</Text>}
+        {sel && !detail && <Group><Loader size="sm" /><Text>Loading…</Text></Group>}
+
+        {detail && (
+          <Stack gap="md">
+            <Group justify="space-between">
+              <Title order={4}>{detail.patient_name}</Title>
+              <Badge color={STATUS_COLOR[detail.claim.status]} size="lg" variant="light">
+                {detail.claim.status}</Badge>
+            </Group>
+
+            <Card withBorder radius="md" padding="md">
+              <Group justify="space-between" mb="xs">
+                <Text fw={600}><IconRobot size={16} style={{ verticalAlign: "-2px" }} /> OncoHealth UM-9 recommendation</Text>
+                <Group gap="xs">
+                  <Text size="xs" c="dimmed">HER2 what-if:</Text>
+                  <SegmentedControl size="xs" value={her2} onChange={setHer2}
+                    data={[{ label: "Resolved", value: "resolved" },
+                           { label: "Positive", value: "positive" },
+                           { label: "Negative", value: "negative" }]} />
+                </Group>
+              </Group>
+              <Button size="sm" variant="light" leftSection={<IconGavel size={16} />}
+                onClick={recommend} loading={loadingRec} mb="sm">
+                Get recommendation
+              </Button>
+
+              {rec && (
+                <Alert color={INDICATOR_COLOR[rec.card?.indicator || "info"]}
+                  title={`${rec.decision} — ${rec.card?.summary || ""}`}>
+                  <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>{rec.card?.detail}</Text>
+                  {rec.card?.links?.map((l, i) => (
+                    <Anchor key={i} href={l.url} size="sm" target="_blank">{l.label}</Anchor>
+                  ))}
+                  <Text size="xs" c="dimmed" mt="xs">evidence used: HER2 {rec.her2_used}</Text>
+                </Alert>
+              )}
+
+              {rec && (
+                <>
+                  <Divider my="sm" label="Decision (human-in-the-loop)" />
+                  <Textarea label="Rationale / note (editable — you can override the AI)"
+                    value={note} onChange={(e) => setNote(e.currentTarget.value)}
+                    autosize minRows={2} maxRows={6} mb="sm" />
+                  <Group>
+                    <Button color="teal" leftSection={<IconThumbUp size={16} />}
+                      onClick={() => decide("approve")} loading={deciding}>Approve</Button>
+                    <Button color="red" variant="light" leftSection={<IconThumbDown size={16} />}
+                      onClick={() => decide("deny")} loading={deciding}>Deny</Button>
+                  </Group>
+                </>
+              )}
+
+              {detail.decision && (
+                <Alert mt="sm" color={detail.decision.decision === "approved" ? "teal" : "red"}
+                  title={`Recorded: ${detail.decision.decision}`}>
+                  <Text size="sm">{detail.decision.rationale}</Text>
+                  {detail.decision.claim_response_id &&
+                    <Text size="xs" c="dimmed" mt={4}>
+                      ClaimResponse/{detail.decision.claim_response_id} written to EHR</Text>}
+                </Alert>
+              )}
+            </Card>
+
+            <ReadinessPanel readiness={detail.readiness} />
+            <EvidencePanel resources={detail.resources} construeCodes={detail.construe_codes}
+              ips={detail.ips_text} regimen={detail.regimen} />
+          </Stack>
+        )}
+      </Grid.Col>
+    </Grid>
+  );
+}

--- a/mopa-breast-pa/ui/src/ProviderView.tsx
+++ b/mopa-breast-pa/ui/src/ProviderView.tsx
@@ -16,6 +16,7 @@ export function ProviderView({ onSubmitted }: { onSubmitted: () => void }) {
   const [intake, setIntake] = useState<IntakeResult | null>(null);
   const [busy, setBusy] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [her2Text, setHer2Text] = useState(DEFAULT_HER2);
   const [her2Positive, setHer2Positive] = useState(true);
@@ -23,17 +24,18 @@ export function ProviderView({ onSubmitted }: { onSubmitted: () => void }) {
   useEffect(() => { api.sampleReport().then((r) => setReport(r.report_text)).catch(() => {}); }, []);
 
   async function runIntake() {
-    setBusy(true); setErr(null); setIntake(null);
+    setBusy(true); setErr(null); setIntake(null); setSubmitted(false);
     try { setIntake(await api.intake(report)); }
     catch (e: any) { setErr(e.message); }
     finally { setBusy(false); }
   }
 
   async function submit() {
-    if (!intake) return;
+    if (!intake || submitting || submitted) return;
     setSubmitting(true); setErr(null);
     try {
       await api.submit(intake.intake_id, her2Text, her2Positive);
+      setSubmitted(true);
       onSubmitted();
     } catch (e: any) { setErr(e.message); }
     finally { setSubmitting(false); }
@@ -90,8 +92,8 @@ export function ProviderView({ onSubmitted }: { onSubmitted: () => void }) {
                     mb="sm" />
                   <Divider mb="sm" />
                   <Button fullWidth color="teal" leftSection={<IconSend size={16} />}
-                    onClick={submit} loading={submitting}>
-                    Submit prior authorization
+                    onClick={submit} loading={submitting} disabled={submitted}>
+                    {submitted ? "Submitted" : "Submit prior authorization"}
                   </Button>
                 </Card>
               </Stack>

--- a/mopa-breast-pa/ui/src/ProviderView.tsx
+++ b/mopa-breast-pa/ui/src/ProviderView.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import {
+  Button, Textarea, Card, Group, Stack, Text, Loader, Alert, Badge, Grid,
+  Switch, TextInput, Divider,
+} from "@mantine/core";
+import { IconUpload, IconSend, IconFileText } from "@tabler/icons-react";
+import { api, type IntakeResult } from "./api";
+import { ReadinessPanel, EvidencePanel } from "./components";
+
+const DEFAULT_HER2 =
+  "HER2 status by reflex in-situ hybridization (ISH): POSITIVE (HER2 gene amplified). " +
+  "Resolves the earlier equivocal IHC 2+ result.";
+
+export function ProviderView({ onSubmitted }: { onSubmitted: () => void }) {
+  const [report, setReport] = useState("");
+  const [intake, setIntake] = useState<IntakeResult | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [her2Text, setHer2Text] = useState(DEFAULT_HER2);
+  const [her2Positive, setHer2Positive] = useState(true);
+
+  useEffect(() => { api.sampleReport().then((r) => setReport(r.report_text)).catch(() => {}); }, []);
+
+  async function runIntake() {
+    setBusy(true); setErr(null); setIntake(null);
+    try { setIntake(await api.intake(report)); }
+    catch (e: any) { setErr(e.message); }
+    finally { setBusy(false); }
+  }
+
+  async function submit() {
+    if (!intake) return;
+    setSubmitting(true); setErr(null);
+    try {
+      await api.submit(intake.intake_id, her2Text, her2Positive);
+      onSubmitted();
+    } catch (e: any) { setErr(e.message); }
+    finally { setSubmitting(false); }
+  }
+
+  return (
+    <Stack gap="md">
+      <Card withBorder radius="md" padding="md">
+        <Group justify="space-between" mb="xs">
+          <Text fw={600}><IconFileText size={16} style={{ verticalAlign: "-2px" }} /> Pathology report</Text>
+          <Badge variant="light" color="gray">prefilled: Jane Smith (HER2 equivocal)</Badge>
+        </Group>
+        <Textarea value={report} onChange={(e) => setReport(e.currentTarget.value)}
+          autosize minRows={6} maxRows={14} />
+        <Group mt="sm">
+          <Button leftSection={<IconUpload size={16} />} onClick={runIntake} loading={busy}>
+            Run intake
+          </Button>
+          <Text size="sm" c="dimmed">lang2fhir → construe → RequestGroup → IPS → readiness gap-check</Text>
+        </Group>
+      </Card>
+
+      {err && <Alert color="red" title="Error">{err}</Alert>}
+      {busy && <Group><Loader size="sm" /><Text>Extracting FHIR, validating codes, generating IPS…</Text></Group>}
+
+      {intake && (
+        <>
+          <Group>
+            <Text fw={600}>Patient:</Text><Text>{intake.patient_name}</Text>
+            {intake.write.ok
+              ? <Badge color="teal" variant="light">
+                  chart written to EHR{intake.patient_id ? ` · Patient/${intake.patient_id}` : ""}</Badge>
+              : <Badge color="gray" variant="light">read-only instance — chart held in memory</Badge>}
+          </Group>
+
+          <Grid>
+            <Grid.Col span={{ base: 12, md: 7 }}>
+              <EvidencePanel resources={intake.resources} construeCodes={intake.construe_codes}
+                ips={intake.ips_text} regimen={intake.regimen} />
+            </Grid.Col>
+            <Grid.Col span={{ base: 12, md: 5 }}>
+              <Stack gap="md">
+                <ReadinessPanel readiness={intake.readiness} />
+                <Card withBorder radius="md" padding="md">
+                  <Text fw={600} mb="xs">Resolve HER2 &amp; submit</Text>
+                  <Text size="sm" c="dimmed" mb="xs">
+                    The reflex ISH result closes the gap. This is written back to the EHR, then a
+                    preauthorization Claim is submitted for payer review.
+                  </Text>
+                  <TextInput label="HER2 result (as reported)" value={her2Text}
+                    onChange={(e) => setHer2Text(e.currentTarget.value)} mb="xs" />
+                  <Switch label={her2Positive ? "HER2 POSITIVE (amplified)" : "HER2 NEGATIVE"}
+                    checked={her2Positive} onChange={(e) => setHer2Positive(e.currentTarget.checked)}
+                    mb="sm" />
+                  <Divider mb="sm" />
+                  <Button fullWidth color="teal" leftSection={<IconSend size={16} />}
+                    onClick={submit} loading={submitting}>
+                    Submit prior authorization
+                  </Button>
+                </Card>
+              </Stack>
+            </Grid.Col>
+          </Grid>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/mopa-breast-pa/ui/src/api.ts
+++ b/mopa-breast-pa/ui/src/api.ts
@@ -1,0 +1,79 @@
+// Thin typed client for the MOPA prior-auth backend (ui_server.py). In dev, Vite proxies /api to
+// the FastAPI server on :8001 (see vite.config.ts), so these are same-origin fetches.
+
+async function req<T>(path: string, method = "GET", body?: unknown): Promise<T> {
+  const res = await fetch(`/api${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error((data && (data.detail || data.message)) || `HTTP ${res.status}`);
+  return data as T;
+}
+
+export interface ReadinessItem { label: string; type: string; code?: string | null; }
+export interface Readiness {
+  satisfied: ReadinessItem[];
+  missing: ReadinessItem[];
+  follow_up_questions: string[];
+}
+export interface IntakeResult {
+  intake_id: string;
+  patient_name: string;
+  patient_id: string | null;
+  resources: any[];
+  construe_codes: Record<string, any[]>;
+  regimen: any;
+  ips_text: string;
+  readiness: Readiness;
+  write: { ok: boolean; error: string | null; patient_id: string | null; locations: string[] };
+}
+export interface ClaimRecord {
+  id: string;
+  fhir_claim_id: string | null;
+  persisted: boolean;
+  patient_name: string;
+  regimen_text: string;
+  created: string;
+  status: "queued" | "approved" | "denied";
+  decision: any;
+}
+export interface ClaimDetail {
+  claim: ClaimRecord;
+  patient_name: string;
+  ips_text: string;
+  regimen: any;
+  resources: any[];
+  readiness: Readiness;
+  construe_codes: Record<string, any[]>;
+  decision: any;
+}
+export interface Card {
+  summary?: string;
+  indicator?: string;
+  detail?: string;
+  links?: { label?: string; url?: string; type?: string }[];
+}
+export interface Recommendation {
+  outcome: string;
+  decision: string;
+  card: Card;
+  coverage: any | null;
+  her2_used: string;
+}
+
+export const api = {
+  health: () => req<{ configured: boolean; provider: string | null }>("/health"),
+  sampleReport: () => req<{ report_text: string }>("/sample-report"),
+  intake: (report_text: string) => req<IntakeResult>("/intake", "POST", { report_text }),
+  submit: (intake_id: string, her2_result: string, her2_positive: boolean) =>
+    req<{ claim: ClaimRecord; her2_writeback: any; readiness: Readiness }>(
+      "/submit", "POST", { intake_id, her2_result, her2_positive }),
+  claims: () => req<{ claims: ClaimRecord[] }>("/claims"),
+  claim: (id: string) => req<ClaimDetail>(`/claims/${id}`),
+  recommend: (id: string, her2_override: string | null) =>
+    req<Recommendation>(`/claims/${id}/recommendation`, "POST", { her2_override }),
+  decide: (id: string, decision: "approve" | "deny", note: string, citations: string[], coverage: any) =>
+    req<{ claim: ClaimRecord }>(`/claims/${id}/decision`, "POST", { decision, note, citations, coverage }),
+};

--- a/mopa-breast-pa/ui/src/components.tsx
+++ b/mopa-breast-pa/ui/src/components.tsx
@@ -1,0 +1,126 @@
+// Shared presentational bits used by both the Provider and Payer views.
+import {
+  Card, Text, Badge, Group, Stack, List, ThemeIcon, Table, Code, Spoiler, Divider,
+} from "@mantine/core";
+import { IconCheck, IconAlertCircle } from "@tabler/icons-react";
+import type { Readiness } from "./api";
+
+function value(r: any): string {
+  const vcc = r.valueCodeableConcept;
+  if (vcc?.text) return vcc.text;
+  if (r.valueString) return r.valueString;
+  if (r.valueQuantity) return `${r.valueQuantity.value ?? ""} ${r.valueQuantity.unit ?? ""}`.trim();
+  return "";
+}
+function label(r: any): string {
+  return r.code?.text || r.code?.coding?.[0]?.display || r.resourceType;
+}
+
+export function ReadinessPanel({ readiness }: { readiness: Readiness }) {
+  return (
+    <Card withBorder radius="md" padding="md">
+      <Group justify="space-between" mb="xs">
+        <Text fw={600}>Readiness gap-check</Text>
+        {readiness.missing.length === 0
+          ? <Badge color="teal">Ready to submit</Badge>
+          : <Badge color="orange">{readiness.missing.length} element(s) missing</Badge>}
+      </Group>
+      <Text size="sm" c="dimmed" mb="xs">
+        Same DataRequirement check the payer runs — run on the provider side, before submitting.
+      </Text>
+      <Group align="flex-start" grow>
+        <div>
+          <Text size="sm" fw={500} mb={4}>On file</Text>
+          <List spacing={2} size="sm" icon={
+            <ThemeIcon color="teal" size={16} radius="xl"><IconCheck size={11} /></ThemeIcon>}>
+            {readiness.satisfied.map((s) => <List.Item key={s.label}>{s.label}</List.Item>)}
+          </List>
+        </div>
+        <div>
+          <Text size="sm" fw={500} mb={4}>Missing / unresolved</Text>
+          {readiness.missing.length === 0
+            ? <Text size="sm" c="dimmed">none</Text>
+            : <List spacing={2} size="sm" icon={
+                <ThemeIcon color="orange" size={16} radius="xl"><IconAlertCircle size={11} /></ThemeIcon>}>
+                {readiness.missing.map((m) => <List.Item key={m.label}>{m.label}</List.Item>)}
+              </List>}
+        </div>
+      </Group>
+      {readiness.follow_up_questions.length > 0 && (
+        <>
+          <Divider my="sm" />
+          <Text size="sm" fw={500} mb={4}>Readiness agent — follow-up</Text>
+          <List size="sm" spacing={2}>
+            {readiness.follow_up_questions.map((q, i) => <List.Item key={i}>{q}</List.Item>)}
+          </List>
+        </>
+      )}
+    </Card>
+  );
+}
+
+export function EvidencePanel({ resources, construeCodes, ips, regimen }: {
+  resources: any[]; construeCodes: Record<string, any[]>; ips: string; regimen: any;
+}) {
+  const codeRows = Object.entries(construeCodes || {})
+    .filter(([k]) => k !== "_errors")
+    .flatMap(([sys, codes]) => (codes || []).map((c: any) => ({ sys, ...c })));
+
+  return (
+    <Stack gap="md">
+      <Card withBorder radius="md" padding="md">
+        <Text fw={600} mb="xs">Regimen</Text>
+        <Text size="sm">{regimen?.code?.text || "TH (paclitaxel + trastuzumab)"}</Text>
+        <Text size="xs" c="dimmed" mt={4}>
+          {(regimen?.extension || []).map((e: any) => e.valueCodeableConcept?.text).filter(Boolean).join(" · ")}
+        </Text>
+      </Card>
+
+      <Card withBorder radius="md" padding="md">
+        <Text fw={600} mb="xs">Structured evidence (mCODE)</Text>
+        <Table striped withRowBorders={false} verticalSpacing={4}>
+          <Table.Tbody>
+            {resources.map((r, i) => (
+              <Table.Tr key={i}>
+                <Table.Td><Badge variant="light" size="sm">{r.resourceType}</Badge></Table.Td>
+                <Table.Td>{label(r)}</Table.Td>
+                <Table.Td><Text fw={500}>{value(r)}</Text></Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      </Card>
+
+      {codeRows.length > 0 && (
+        <Card withBorder radius="md" padding="md">
+          <Text fw={600} mb="xs">Validated codes (with citations)</Text>
+          <Table verticalSpacing={4}>
+            <Table.Thead>
+              <Table.Tr><Table.Th>System</Table.Th><Table.Th>Code</Table.Th>
+                <Table.Th>Description</Table.Th><Table.Th>Citation</Table.Th></Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {codeRows.map((c: any, i: number) => (
+                <Table.Tr key={i}>
+                  <Table.Td><Code>{c.sys}</Code></Table.Td>
+                  <Table.Td><Code>{c.code}</Code></Table.Td>
+                  <Table.Td>{c.description}</Table.Td>
+                  <Table.Td><Text size="xs" c="dimmed">{c.citations?.[0]?.text || ""}</Text></Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Card>
+      )}
+
+      {ips && (
+        <Card withBorder radius="md" padding="md">
+          <Text fw={600} mb="xs">International Patient Summary</Text>
+          <Spoiler maxHeight={140} showLabel="Show full summary" hideLabel="Hide">
+            <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>{ips}</Text>
+          </Spoiler>
+        </Card>
+      )}
+    </Stack>
+  );
+}

--- a/mopa-breast-pa/ui/src/main.tsx
+++ b/mopa-breast-pa/ui/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { MantineProvider } from "@mantine/core";
+import "@mantine/core/styles.css";
+import { App } from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <MantineProvider defaultColorScheme="light">
+      <App />
+    </MantineProvider>
+  </React.StrictMode>
+);

--- a/mopa-breast-pa/ui/tsconfig.json
+++ b/mopa-breast-pa/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/mopa-breast-pa/ui/vite.config.ts
+++ b/mopa-breast-pa/ui/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// Dev: proxy /api to the FastAPI backend (ui_server.py on :8001) so the browser makes same-origin
+// requests and CORS is a non-issue while developing.
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": { target: "http://localhost:8001", changeOrigin: true },
+    },
+  },
+});

--- a/mopa-breast-pa/ui_server.py
+++ b/mopa-breast-pa/ui_server.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""FastAPI backend for the MOPA prior-auth UI.
+
+Two personas over one pipeline:
+  Provider  - paste a pathology report -> lang2fhir/construe/IPS + readiness gap-check (HER2) ->
+              resolve HER2 -> submit a preauthorization Claim to the EHR (Medplum, via PhenoML).
+  Payer     - review the queue of Claims -> get the OncoHealth UM-9 agent's recommendation
+              (rebuilds the CDS Hooks order-sign envelope + runs cds_hooks_server/evaluate.py) ->
+              approve/deny (human-in-the-loop) -> write a ClaimResponse (+ Coverage on approve).
+
+Runs at the demo top level so `import pipeline, pa_fhir`, `from common import ...`,
+`from cds_hooks_server import evaluate`, and `from step2_cdshooks import build_envelope` resolve
+exactly like the step scripts. The UM-9 and readiness agents are built ONCE at startup (lifespan)
+and deleted on shutdown - never per request.
+
+Run:  .venv/bin/uvicorn ui_server:app --port 8001 --reload
+"""
+import uuid
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from common import load_env, make_client, resolve_provider, parse_json, retry, cleanup
+from cds_hooks_server import evaluate
+from step2_cdshooks import build_envelope, classify
+import pipeline
+import pa_fhir
+
+READINESS_PROMPT = (
+    "You are a prior-authorization readiness reviewer for medical oncology. You are given the "
+    "ordered regimen and the list of required data elements that are missing or unresolved. "
+    "Write one concise, specific follow-up question per missing element to collect it from the "
+    'care team. Return ONLY JSON: {"follow_up_questions":[...]}')
+
+# In-memory cache of intake results keyed by intake_id, so /submit does not re-run the (paid)
+# lang2fhir/construe extraction. A demo-scale dict; fine to lose on restart.
+INTAKES: dict = {}
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.client = None
+    app.state.provider = None
+    app.state.um9_agent_id = None
+    app.state.readiness_agent_id = None
+    app.state.library = evaluate.load_library()
+    app.state.created = {"agents": [], "prompts": []}
+    app.state.writable = False
+    try:
+        env = load_env()
+        client = make_client(env)
+        provider = resolve_provider(client, env)
+        app.state.client, app.state.provider = client, provider
+        # Build both agents once (UM-9 for judgment, readiness for phrasing follow-ups).
+        app.state.um9_agent_id = evaluate.build_agent_once(client, provider, app.state.created)
+        rp = client.agent.prompts.create(name="mopa-readiness-ui", content=READINESS_PROMPT,
+                                         description="MOPA oncology PA readiness reviewer (UI).")
+        app.state.created["prompts"].append(rp.data.id)
+        ra = client.agent.create(name="MOPA Readiness Agent (UI)", prompts=[rp.data.id],
+                                 provider=provider, tags=["mopa", "readiness", "ui"])
+        app.state.created["agents"].append(ra.data.id)
+        app.state.readiness_agent_id = ra.data.id
+        print(f"[ui] agents ready: um9={app.state.um9_agent_id} readiness={ra.data.id}")
+    except SystemExit as e:
+        print(f"[ui] no credentials; API will return 503 until configured ({e})")
+    except Exception as e:
+        print(f"[ui] agent init failed: {type(e).__name__}: {e}")
+    try:
+        yield
+    finally:
+        if app.state.client and app.state.created["agents"]:
+            cleanup(app.state.client, app.state.created)
+
+
+app = FastAPI(title="MOPA prior-auth UI backend", lifespan=lifespan)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://localhost:5174", "http://127.0.0.1:5173",
+                   "http://127.0.0.1:5174", "http://localhost:3000"],
+    allow_credentials=True, allow_methods=["*"], allow_headers=["*"],
+)
+
+
+def _require_client():
+    if app.state.client is None:
+        raise HTTPException(503, "PhenoML client not initialized. Set PHENOML_CLIENT_ID / "
+                                 "PHENOML_CLIENT_SECRET (and PHENOML_FHIR_PROVIDER_ID) and restart.")
+    return app.state.client, app.state.provider
+
+
+# ---------- helpers -------------------------------------------------------
+def _chart_resource_dicts(artifacts: dict, extra=None) -> list:
+    """Plain resource dicts (chart entries + regimen) for the readiness gap-check."""
+    res = [e["resource"] for e in artifacts["chart_resources"]] + [artifacts["regimen_requestgroup"]]
+    return res + (extra or [])
+
+
+def _readiness(client, artifacts: dict, extra=None) -> dict:
+    gap = evaluate.check_data_requirements(_chart_resource_dicts(artifacts, extra), app.state.library)
+    follow_ups = []
+    if gap["missing"] and app.state.readiness_agent_id:
+        msg = ("Ordered regimen: TH (paclitaxel + trastuzumab), adjuvant, breast cancer.\n"
+               "Missing or unresolved required elements: "
+               + ", ".join(m["label"] for m in gap["missing"]) + "\nReturn the JSON.")
+        try:
+            r = retry(client.agent.chat.send, label="readiness.chat",
+                      agent_id=app.state.readiness_agent_id, message=msg)
+            follow_ups = parse_json(r.response).get("follow_up_questions", [])
+        except Exception as e:
+            follow_ups = [f"(readiness agent unavailable: {type(e).__name__})"]
+    return {"satisfied": gap["satisfied"], "missing": gap["missing"],
+            "follow_up_questions": follow_ups}
+
+
+def _static_her2_entry(patient_url: str, positive: bool) -> dict:
+    """A static HER2 Observation entry (no network call) for the reviewer's what-if toggle."""
+    value = "Positive (HER2 amplified)" if positive else "Negative (HER2 not amplified)"
+    return {"fullUrl": f"urn:uuid:{uuid.uuid4()}", "request": {"method": "POST", "url": "Observation"},
+            "resource": {"resourceType": "Observation", "status": "final",
+                         "code": {"text": "HER2 [Presence] in Breast cancer specimen by Immune stain",
+                                  "coding": [{"system": "http://loinc.org", "code": "85319-2",
+                                              "display": "HER2 [Presence] in Breast cancer specimen by Immune stain"}]},
+                         "valueCodeableConcept": {"text": value},
+                         "subject": {"reference": patient_url}}}
+
+
+# ---------- request models ------------------------------------------------
+class IntakeReq(BaseModel):
+    report_text: str
+
+
+class SubmitReq(BaseModel):
+    intake_id: str
+    her2_result: str = ("HER2 status by reflex in-situ hybridization (ISH): POSITIVE (HER2 gene "
+                        "amplified). Resolves the earlier equivocal IHC 2+ result.")
+    her2_positive: bool = True
+
+
+class RecommendReq(BaseModel):
+    her2_override: str | None = None   # None -> use resolved HER2; "positive" / "negative" -> what-if
+
+
+class DecisionReq(BaseModel):
+    decision: str                       # "approve" | "deny"
+    note: str = ""
+    citations: list = []
+    coverage: dict | None = None        # the systemAction from the recommendation, on approve
+
+
+# ---------- endpoints -----------------------------------------------------
+@app.get("/api/health")
+def health():
+    return {"status": "healthy", "configured": app.state.client is not None,
+            "provider": app.state.provider, "um9_agent": app.state.um9_agent_id}
+
+
+@app.get("/api/sample-report")
+def sample_report():
+    return {"report_text": (pipeline.HERE / "sample_path_report.txt").read_text()}
+
+
+@app.post("/api/intake")
+def intake(req: IntakeReq):
+    client, provider = _require_client()
+    if not (req.report_text or "").strip():
+        raise HTTPException(400, "report_text is required")
+    artifacts = pipeline.run_intake(client, provider, req.report_text)
+    readiness = _readiness(client, artifacts)
+    intake_id = uuid.uuid4().hex[:12]
+    INTAKES[intake_id] = {**artifacts, "readiness": readiness}
+    return {
+        "intake_id": intake_id,
+        "patient_name": pa_fhir.patient_name(artifacts),
+        "patient_id": artifacts["patient_id"],
+        "resources": [e["resource"] for e in artifacts["chart_resources"]],
+        "construe_codes": artifacts["construe_codes"],
+        "regimen": artifacts["regimen_requestgroup"],
+        "ips_text": artifacts["ips_text"],
+        "readiness": readiness,
+        "write": artifacts["write"],
+    }
+
+
+@app.post("/api/submit")
+def submit(req: SubmitReq):
+    client, provider = _require_client()
+    artifacts = INTAKES.get(req.intake_id)
+    if not artifacts:
+        raise HTTPException(404, "unknown intake_id (re-run intake)")
+
+    # Resolve HER2 and write it back to the EHR, exactly like Step 1.5.
+    her2_entry = pipeline.build_her2_observation(client, req.her2_result,
+                                                 artifacts["patient_full_url"], positive=req.her2_positive)
+    write = pipeline.persist_chart(client, provider, {"resourceType": "Bundle", "type": "transaction",
+                                                      "entry": []}, [her2_entry], [])
+    readiness_after = _readiness(client, artifacts, extra=[her2_entry["resource"]])
+
+    snapshot = {
+        "bundle": artifacts["bundle"],
+        "chart_resources": artifacts["chart_resources"],
+        "regimen_requestgroup": artifacts["regimen_requestgroup"],
+        "draft_order_entries": artifacts["draft_order_entries"],
+        "patient_id": artifacts["patient_id"],
+        "patient_full_url": artifacts["patient_full_url"],
+        "requirements": app.state.library,
+        "her2_entry": her2_entry,
+        "ips_text": artifacts["ips_text"],
+        "construe_codes": artifacts["construe_codes"],
+        "readiness": readiness_after,
+        "nccn_fact": {"regimen": "TH", "indication": "adjuvant HER2+ breast", "nccn_category": "1"},
+    }
+    record = pa_fhir.submit_claim(client, provider, snapshot)
+    return {"claim": pa_fhir._light(record), "her2_writeback": write, "readiness": readiness_after}
+
+
+@app.get("/api/claims")
+def claims():
+    return {"claims": pa_fhir.list_claims()}
+
+
+@app.get("/api/claims/{claim_id}")
+def claim_detail(claim_id: str):
+    record = pa_fhir.get_claim(claim_id)
+    if not record:
+        raise HTTPException(404, "unknown claim")
+    snap = record["snapshot"]
+    return {
+        "claim": pa_fhir._light(record),
+        "patient_name": record["patient_name"],
+        "ips_text": snap.get("ips_text"),
+        "regimen": snap.get("regimen_requestgroup"),
+        "resources": [e["resource"] for e in snap.get("chart_resources", [])]
+                     + ([snap["her2_entry"]["resource"]] if snap.get("her2_entry") else []),
+        "readiness": snap.get("readiness"),
+        "construe_codes": snap.get("construe_codes"),
+        "decision": record.get("decision"),
+    }
+
+
+@app.post("/api/claims/{claim_id}/recommendation")
+def recommendation(claim_id: str, req: RecommendReq):
+    client, provider = _require_client()
+    record = pa_fhir.get_claim(claim_id)
+    if not record:
+        raise HTTPException(404, "unknown claim")
+    snap = record["snapshot"]
+
+    # Pick the HER2 evidence: resolved (default, as submitted) or a reviewer what-if override.
+    if req.her2_override == "negative":
+        her2_entry = _static_her2_entry(snap["patient_full_url"], positive=False)
+    elif req.her2_override == "positive":
+        her2_entry = _static_her2_entry(snap["patient_full_url"], positive=True)
+    else:  # None -> the resolved HER2 collected at submit
+        her2_entry = snap.get("her2_entry")
+
+    envelope = build_envelope({**snap, "requirements": app.state.library}, "order-sign",
+                              her2_entry=her2_entry)
+    resp = evaluate.evaluate(client, app.state.um9_agent_id, envelope, app.state.library)
+    outcome = classify(resp)
+    card = (resp.get("cards") or [{}])[0]
+    coverage = (resp.get("systemActions") or [None])[0]
+    decision = {"pre-approved": "APPROVED", "deny": "DENIED",
+                "needs-more-info": "NEEDS_INFO"}.get(outcome, outcome.upper())
+    return {"outcome": outcome, "decision": decision, "card": card,
+            "coverage": coverage, "her2_used": req.her2_override or "resolved"}
+
+
+@app.post("/api/claims/{claim_id}/decision")
+def decision(claim_id: str, req: DecisionReq):
+    client, provider = _require_client()
+    if req.decision.lower() not in ("approve", "approved", "deny", "denied"):
+        raise HTTPException(400, "decision must be 'approve' or 'deny'")
+    try:
+        record = pa_fhir.record_decision(client, provider, claim_id, req.decision, req.note,
+                                         req.citations, req.coverage)
+    except KeyError:
+        raise HTTPException(404, "unknown claim")
+    return {"claim": pa_fhir._light(record)}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("ui_server:app", host="127.0.0.1", port=8001, reload=True)

--- a/mopa-breast-pa/ui_server.py
+++ b/mopa-breast-pa/ui_server.py
@@ -38,6 +38,11 @@ READINESS_PROMPT = (
 # lang2fhir/construe extraction. A demo-scale dict; fine to lose on restart.
 INTAKES: dict = {}
 
+# intake_id -> claim id, for intakes already submitted. An intake is consumed (popped from INTAKES)
+# on a successful submit and recorded here so a repeat submit is rejected instead of queuing a
+# duplicate Claim for the same intake. Same demo-scale lifetime as INTAKES.
+SUBMITTED: dict = {}
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -88,6 +93,25 @@ def _require_client():
         raise HTTPException(503, "PhenoML client not initialized. Set PHENOML_CLIENT_ID / "
                                  "PHENOML_CLIENT_SECRET (and PHENOML_FHIR_PROVIDER_ID) and restart.")
     return app.state.client, app.state.provider
+
+
+def _require_um9():
+    """Guard endpoints that need the UM-9 review agent. The client can be initialized while agent
+    setup failed at startup, so a live client does not imply a usable UM-9 agent; fail with a clear
+    503 instead of calling the agent with a missing id and erroring at runtime."""
+    if app.state.um9_agent_id is None:
+        raise HTTPException(503, "UM-9 review agent unavailable (agent init failed at startup); "
+                                 "check backend logs and restart.")
+    return app.state.um9_agent_id
+
+
+def _patient_reference(snap: dict) -> str:
+    """Reference for the resolved-HER2 Observation's subject. Prefer the server-assigned Patient id
+    (resolvable in a standalone write-back transaction) over the bundle-local urn:uuid, which many
+    FHIR servers reject outside its original bundle. Falls back to the urn:uuid on a read-only
+    instance where the chart was never persisted."""
+    pid = snap.get("patient_id")
+    return f"Patient/{pid}" if pid else snap["patient_full_url"]
 
 
 # ---------- helpers -------------------------------------------------------
@@ -188,11 +212,14 @@ def submit(req: SubmitReq):
     client, provider = _require_client()
     artifacts = INTAKES.get(req.intake_id)
     if not artifacts:
+        if req.intake_id in SUBMITTED:
+            raise HTTPException(409, f"intake already submitted as claim {SUBMITTED[req.intake_id]}")
         raise HTTPException(404, "unknown intake_id (re-run intake)")
 
-    # Resolve HER2 and write it back to the EHR, exactly like Step 1.5.
+    # Resolve HER2 and write it back to the EHR, exactly like Step 1.5. Reference the persisted
+    # Patient by server id so the standalone write-back transaction resolves the subject.
     her2_entry = pipeline.build_her2_observation(client, req.her2_result,
-                                                 artifacts["patient_full_url"], positive=req.her2_positive)
+                                                 _patient_reference(artifacts), positive=req.her2_positive)
     write = pipeline.persist_chart(client, provider, {"resourceType": "Bundle", "type": "transaction",
                                                       "entry": []}, [her2_entry], [])
     readiness_after = _readiness(client, artifacts, extra=[her2_entry["resource"]])
@@ -209,9 +236,19 @@ def submit(req: SubmitReq):
         "ips_text": artifacts["ips_text"],
         "construe_codes": artifacts["construe_codes"],
         "readiness": readiness_after,
-        "nccn_fact": {"regimen": "TH", "indication": "adjuvant HER2+ breast", "nccn_category": "1"},
+        "nccn_fact": {
+            "regimen": "TH",
+            "her2_positive": req.her2_positive,
+            "indication": "adjuvant HER2+ breast" if req.her2_positive else "adjuvant HER2- breast",
+            "nccn_category": "1" if req.her2_positive
+                             else "not supported (trastuzumab requires HER2-positive)",
+        },
     }
     record = pa_fhir.submit_claim(client, provider, snapshot)
+    # Consume the intake so returning to the provider tab (or a double-click) cannot queue a
+    # duplicate Claim for the same intake.
+    INTAKES.pop(req.intake_id, None)
+    SUBMITTED[req.intake_id] = record["id"]
     return {"claim": pa_fhir._light(record), "her2_writeback": write, "readiness": readiness_after}
 
 
@@ -242,6 +279,7 @@ def claim_detail(claim_id: str):
 @app.post("/api/claims/{claim_id}/recommendation")
 def recommendation(claim_id: str, req: RecommendReq):
     client, provider = _require_client()
+    um9_agent_id = _require_um9()
     record = pa_fhir.get_claim(claim_id)
     if not record:
         raise HTTPException(404, "unknown claim")
@@ -249,15 +287,15 @@ def recommendation(claim_id: str, req: RecommendReq):
 
     # Pick the HER2 evidence: resolved (default, as submitted) or a reviewer what-if override.
     if req.her2_override == "negative":
-        her2_entry = _static_her2_entry(snap["patient_full_url"], positive=False)
+        her2_entry = _static_her2_entry(_patient_reference(snap), positive=False)
     elif req.her2_override == "positive":
-        her2_entry = _static_her2_entry(snap["patient_full_url"], positive=True)
+        her2_entry = _static_her2_entry(_patient_reference(snap), positive=True)
     else:  # None -> the resolved HER2 collected at submit
         her2_entry = snap.get("her2_entry")
 
     envelope = build_envelope({**snap, "requirements": app.state.library}, "order-sign",
                               her2_entry=her2_entry)
-    resp = evaluate.evaluate(client, app.state.um9_agent_id, envelope, app.state.library)
+    resp = evaluate.evaluate(client, um9_agent_id, envelope, app.state.library)
     outcome = classify(resp)
     card = (resp.get("cards") or [{}])[0]
     coverage = (resp.get("systemActions") or [None])[0]
@@ -277,6 +315,8 @@ def decision(claim_id: str, req: DecisionReq):
                                          req.citations, req.coverage)
     except KeyError:
         raise HTTPException(404, "unknown claim")
+    except ValueError as e:
+        raise HTTPException(409, str(e))
     return {"claim": pa_fhir._light(record)}
 
 

--- a/mopa-lang2fhir/.env.example
+++ b/mopa-lang2fhir/.env.example
@@ -1,0 +1,10 @@
+# PhenoML API credentials, OAuth client credentials.
+PHENOML_CLIENT_ID=your_client_id_here
+PHENOML_CLIENT_SECRET=your_client_secret_here
+
+# Optional: point the SDK at a specific PhenoML instance.
+PHENOML_BASE_URL=
+
+# Required only for "Write Bundle to FHIR Provider".
+# The demo will not borrow a provider for writes.
+PHENOML_FHIR_PROVIDER_ID=your_fhir_provider_uuid_here

--- a/mopa-lang2fhir/.gitignore
+++ b/mopa-lang2fhir/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+.env
+.state/
+__pycache__/
+ui/node_modules/
+ui/dist/

--- a/mopa-lang2fhir/Makefile
+++ b/mopa-lang2fhir/Makefile
@@ -1,0 +1,47 @@
+# MOPA Lang2FHIR demo tasks.
+#
+#   make dev       run backend (:8002) and frontend (:5174)
+#   make setup     create the venv and install backend/frontend deps
+#   make backend   run FastAPI only
+#   make frontend  run Vite only
+
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+VENV := .venv
+UVICORN := $(VENV)/bin/uvicorn
+BACKEND_PORT ?= 8002
+
+$(VENV): requirements.txt
+	uv venv --python 3.12 $(VENV)
+	uv pip install --python $(VENV)/bin/python -r requirements.txt
+	@touch $(VENV)
+
+ui/node_modules: ui/package.json
+	cd ui && npm install
+	@touch ui/node_modules
+
+.PHONY: setup
+setup: $(VENV) ui/node_modules ## Create the venv and install deps
+
+.PHONY: backend
+backend: $(VENV) ## Run the FastAPI backend
+	$(UVICORN) ui_server:app --port $(BACKEND_PORT) --reload
+
+.PHONY: frontend
+frontend: ui/node_modules ## Run the Vite frontend
+	cd ui && npm run dev
+
+.PHONY: dev
+dev: setup ## Run backend and frontend together
+	@echo "backend  -> http://localhost:$(BACKEND_PORT)"
+	@echo "frontend -> http://localhost:5174"
+	@trap 'kill 0' EXIT INT TERM; \
+	  $(UVICORN) ui_server:app --port $(BACKEND_PORT) --reload & \
+	  ( cd ui && npm run dev ) & \
+	  wait
+
+.PHONY: help
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+	  | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'

--- a/mopa-lang2fhir/README.md
+++ b/mopa-lang2fhir/README.md
@@ -1,0 +1,93 @@
+# MOPA Lang2FHIR Demo
+
+This demo reuses the breast cancer data from `mopa-breast-pa` and focuses on the provider-side data package:
+
+1. Select the prior-auth artifacts that matter for Lang2FHIR.
+2. Generate oncology FHIR resources and a transaction Bundle.
+3. Optionally write the Bundle through PhenoML's FHIR Proxy to the FHIR Provider named in `.env`.
+4. Run FHIR2Summary with `summary.create(..., mode="ips")` against the in-memory Bundle.
+5. Optionally upload local OncoHealth demo profiles to Lang2FHIR.
+
+It does not run the payer queue, CDS Hooks review, Claim review, or UM-9 recommendation flow.
+
+## Prerequisites
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Set these values in `mopa-lang2fhir/.env`:
+
+```bash
+PHENOML_CLIENT_ID=...
+PHENOML_CLIENT_SECRET=...
+PHENOML_BASE_URL=
+PHENOML_FHIR_PROVIDER_ID=...
+```
+
+`PHENOML_FHIR_PROVIDER_ID` is required only for the write action. The demo does not borrow a provider for writes.
+
+## Run
+
+```bash
+make dev
+```
+
+Open http://localhost:5174.
+
+Manual backend/frontend:
+
+```bash
+.venv/bin/uvicorn ui_server:app --port 8002 --reload
+cd ui && npm install && npm run dev
+```
+
+## API
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/health` | Credential state, configured FHIR Provider id, and profile upload capability |
+| `GET /api/source-data` | Source report, data map, requirements, and regimen template |
+| `POST /api/extract` | Run Lang2FHIR and assemble the transaction Bundle |
+| `POST /api/fhir/write` | Write the transaction Bundle through the FHIR Proxy |
+| `POST /api/summary` | Run FHIR2Summary IPS mode |
+| `GET /api/profiles` | List local OncoHealth demo profiles |
+| `POST /api/profiles/upload` | Upload local profiles when the SDK supports `lang2fhir.upload_profile` |
+
+## Source Data
+
+The demo reads these files from `../mopa-breast-pa`:
+
+| File | Use |
+|---|---|
+| `sample_path_report.txt` | Lang2FHIR clinical text input |
+| `mopa_requirements.json` | Data selection map for oncology evidence |
+| `regimen_th.json` | TH regimen RequestGroup template |
+
+`policy_um9_oncohealth.md` and `cds_hooks_server/` are intentionally not used because this demo stops before payer adjudication.
+
+## FHIR Write
+
+The write endpoint calls:
+
+```python
+client.fhir.execute_bundle(
+    fhir_provider_id=PHENOML_FHIR_PROVIDER_ID,
+    request=bundle,
+)
+```
+
+The response reports created resource locations and the assigned `Patient/{id}` when the FHIR Provider returns one. If the FHIR Provider rejects the write, summary generation still works because it uses the in-memory Bundle.
+
+## Profiles
+
+Local demo profiles live in `profiles/`:
+
+- `oncohealth-oncology-evidence-observation.json`
+- `oncohealth-regimen-requestgroup.json`
+- `oncohealth-summary-package.json`
+
+The upload action is optional. If the installed SDK does not expose `client.lang2fhir.upload_profile`, the UI reports that and the rest of the demo still works.

--- a/mopa-lang2fhir/common.py
+++ b/mopa-lang2fhir/common.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Shared helpers for the MOPA Lang2FHIR demo."""
+import json
+import os
+import time
+from pathlib import Path
+
+import httpx
+from dotenv import dotenv_values
+from phenoml import PhenomlClient
+
+HERE = Path(__file__).resolve().parent
+SOURCE_DEMO = HERE.parent / "mopa-breast-pa"
+
+
+def load_env() -> dict:
+    env = dict(os.environ)
+    for path in (HERE.parent / ".env", HERE / ".env"):
+        if path.exists():
+            env.update({
+                k: (v or "").strip().strip('"').strip("'")
+                for k, v in dotenv_values(path).items()
+            })
+    return env
+
+
+def make_client(env: dict) -> PhenomlClient:
+    cid = env.get("PHENOML_CLIENT_ID")
+    secret = env.get("PHENOML_CLIENT_SECRET")
+    if not cid or not secret:
+        raise RuntimeError("Set PHENOML_CLIENT_ID and PHENOML_CLIENT_SECRET in mopa-lang2fhir/.env")
+
+    kw = {"timeout": float(env.get("PHENOML_TIMEOUT", "300")), "max_retries": 0}
+    if env.get("PHENOML_BASE_URL"):
+        kw["base_url"] = env["PHENOML_BASE_URL"]
+    return PhenomlClient(client_id=cid, client_secret=secret, **kw)
+
+
+def configured_provider(env: dict) -> str | None:
+    value = (env.get("PHENOML_FHIR_PROVIDER_ID") or "").strip()
+    if not value or value == "your_fhir_provider_uuid_here":
+        return None
+    return value
+
+
+def as_dict(obj):
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(by_alias=True, exclude_none=True)
+    if isinstance(obj, list):
+        return [as_dict(x) for x in obj]
+    return obj
+
+
+def retry(fn, *args, attempts=3, base=4, label="", **kwargs):
+    for i in range(1, attempts + 1):
+        try:
+            return fn(*args, **kwargs)
+        except httpx.TransportError:
+            if i == attempts:
+                raise
+            time.sleep(base * i)
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text())

--- a/mopa-lang2fhir/pipeline.py
+++ b/mopa-lang2fhir/pipeline.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Lang2FHIR extraction, Bundle assembly, summary, and FHIR Proxy write."""
+import copy
+import json
+import uuid
+
+from common import SOURCE_DEMO, as_dict, configured_provider, read_json, retry
+
+LOINC = "http://loinc.org"
+SNOMED = "http://snomed.info/sct"
+
+SAMPLE_REPORT = SOURCE_DEMO / "sample_path_report.txt"
+REQUIREMENTS = SOURCE_DEMO / "mopa_requirements.json"
+REGIMEN = SOURCE_DEMO / "regimen_th.json"
+
+CHART_SPECS = [
+    ("condition-encounter-diagnosis", SNOMED, "254837009", "Malignant neoplasm of breast",
+     "Invasive ductal carcinoma of the right breast, Nottingham histologic grade 2.", None),
+    ("observation-clinical-result", LOINC, "21908-9", "Stage group.clinical Cancer",
+     "Cancer clinical stage group: Stage IIB (T2 N1 M0), AJCC 8th edition.", "Stage IIB"),
+    ("observation-lab", LOINC, "85337-4",
+     "Estrogen receptor Ag [Presence] in Breast cancer specimen by Immune stain",
+     "Estrogen receptor (ER) status by immunohistochemistry: negative, 0% nuclear staining.",
+     "Negative 0%"),
+    ("observation-lab", LOINC, "85339-0",
+     "Progesterone receptor Ag [Presence] in Breast cancer specimen by Immune stain",
+     "Progesterone receptor (PR) status by immunohistochemistry: negative, 0% nuclear staining.",
+     "Negative 0%"),
+    ("observation-clinical-result", LOINC, "89247-1", "ECOG performance status",
+     "ECOG performance status: 0 (fully active).", "0 (fully active)"),
+]
+
+DEFAULT_HER2 = (
+    "HER2 status by reflex in-situ hybridization (ISH): POSITIVE (HER2 gene amplified). "
+    "Resolves the earlier equivocal IHC 2+ result."
+)
+
+
+def source_data() -> dict:
+    requirements = read_json(REQUIREMENTS)
+    regimen = read_json(REGIMEN)
+    mapped = []
+    for item in requirements.get("dataRequirement", []):
+        codes = [c for cf in item.get("codeFilter", []) for c in cf.get("code", [])]
+        label = codes[0].get("display") if codes else item["type"]
+        mapped.append({
+            "type": item["type"],
+            "label": label,
+            "code": codes[0].get("code") if codes else None,
+            "source": "pathology report" if item["type"] != "RequestGroup" else "regimen template",
+            "used": True,
+        })
+    return {
+        "report_text": SAMPLE_REPORT.read_text(),
+        "requirements": requirements,
+        "mapped_requirements": mapped,
+        "regimen_template": regimen,
+        "artifacts": [
+            {"name": "sample_path_report.txt", "use": "Lang2FHIR clinical text input", "used": True},
+            {"name": "mopa_requirements.json", "use": "selects oncology facts for the Bundle", "used": True},
+            {"name": "regimen_th.json", "use": "RequestGroup template for TH regimen", "used": True},
+            {"name": "policy_um9_oncohealth.md", "use": "payer adjudication only", "used": False},
+            {"name": "cds_hooks_server/", "use": "payer CDS Hooks exchange only", "used": False},
+        ],
+    }
+
+
+def _entry(resource: dict) -> dict:
+    return {
+        "fullUrl": f"urn:uuid:{uuid.uuid4()}",
+        "resource": resource,
+        "request": {"method": "POST", "url": resource["resourceType"]},
+    }
+
+
+def _lang2fhir(client, resource: str, text: str, patient_url: str | None = None) -> dict:
+    out = as_dict(retry(client.lang2fhir.create, label=f"lang2fhir.{resource}",
+                       version="R4", resource=resource, text=text))
+    if patient_url:
+        out["subject"] = {"reference": patient_url}
+    return out
+
+
+def _stamp(resource: dict, system: str, code: str, display: str, value: str | None = None) -> dict:
+    codeable = resource.setdefault("code", {})
+    codings = codeable.setdefault("coding", [])
+    if not any(c.get("system") == system and c.get("code") == code for c in codings):
+        codings.append({"system": system, "code": code, "display": display})
+    codeable.setdefault("text", display)
+    if value is not None:
+        resource["valueCodeableConcept"] = {"text": value}
+    return resource
+
+
+def patient_full_url(bundle: dict) -> str:
+    patients = [
+        e for e in bundle.get("entry", [])
+        if e.get("resource", {}).get("resourceType") == "Patient"
+    ]
+    if len(patients) != 1:
+        raise ValueError(f"expected exactly 1 Patient in Lang2FHIR bundle, found {len(patients)}")
+    return patients[0]["fullUrl"]
+
+
+def _structure_chart(client, patient_url: str) -> list[dict]:
+    entries = []
+    for resource, system, code, display, text, value in CHART_SPECS:
+        item = _stamp(_lang2fhir(client, resource, text, patient_url), system, code, display, value)
+        entries.append(_entry(item))
+    return entries
+
+
+def _her2_observation(client, patient_url: str, text: str, positive: bool) -> dict:
+    obs = _lang2fhir(client, "observation-lab", text, patient_url)
+    value = "Positive (HER2 amplified)" if positive else "Negative (HER2 not amplified)"
+    obs = _stamp(obs, LOINC, "85319-2",
+                 "HER2 [Presence] in Breast cancer specimen by Immune stain", value)
+    return _entry(obs)
+
+
+def _assemble_regimen(client, patient_url: str) -> tuple[dict, list[dict]]:
+    paclitaxel = _lang2fhir(
+        client,
+        "medicationrequest",
+        "Paclitaxel 80 mg/m2 intravenous, weekly, adjuvant therapy for breast cancer.",
+        patient_url,
+    )
+    trastuzumab = _lang2fhir(
+        client,
+        "medicationrequest",
+        "Trastuzumab intravenous, weekly, HER2-targeted adjuvant therapy for breast cancer.",
+        patient_url,
+    )
+    pac_entry = _entry(paclitaxel)
+    tra_entry = _entry(trastuzumab)
+
+    regimen = read_json(REGIMEN)
+    regimen["subject"] = {"reference": patient_url}
+    regimen["meta"] = {
+        "profile": ["https://pheno.ml/demo/oncohealth/StructureDefinition/oncohealth-regimen-requestgroup"]
+    }
+    regimen["action"][0]["resource"] = {"reference": pac_entry["fullUrl"]}
+    regimen["action"][1]["resource"] = {"reference": tra_entry["fullUrl"]}
+    rg_entry = _entry(regimen)
+    return regimen, [rg_entry, pac_entry, tra_entry]
+
+
+def _summary_bundle(transaction_bundle: dict) -> dict:
+    bundle = copy.deepcopy(transaction_bundle)
+    bundle["type"] = "collection"
+    for entry in bundle.get("entry", []):
+        entry.pop("request", None)
+    return bundle
+
+
+def extract(client, report_text: str, include_her2: bool = True,
+            her2_result: str = DEFAULT_HER2, her2_positive: bool = True) -> dict:
+    multi = retry(client.lang2fhir.create_multi, label="create_multi",
+                  text=report_text, version="R4")
+    base_bundle = as_dict(multi.bundle)
+    extracted = as_dict(multi.resources)
+    patient_url = patient_full_url(base_bundle)
+
+    chart_entries = _structure_chart(client, patient_url)
+    regimen, regimen_entries = _assemble_regimen(client, patient_url)
+    her2_entry = _her2_observation(client, patient_url, her2_result, her2_positive) if include_her2 else None
+
+    transaction = copy.deepcopy(base_bundle)
+    transaction["type"] = "transaction"
+    transaction["entry"].extend(chart_entries + regimen_entries + ([her2_entry] if her2_entry else []))
+
+    selected_resources = [e["resource"] for e in chart_entries + regimen_entries]
+    if her2_entry:
+        selected_resources.append(her2_entry["resource"])
+
+    return {
+        "bundle": transaction,
+        "summary_bundle": _summary_bundle(transaction),
+        "resources": selected_resources,
+        "base_resources": extracted,
+        "regimen": regimen,
+        "patient_full_url": patient_url,
+        "source_map": source_data()["mapped_requirements"],
+    }
+
+
+def summarize(client, bundle: dict) -> dict:
+    resp = retry(client.summary.create, label="summary.create", fhir_resources=bundle, mode="ips")
+    return {"summary": getattr(resp, "summary", "") or as_dict(resp).get("summary", "")}
+
+
+def write_bundle(client, env: dict, bundle: dict) -> dict:
+    provider = configured_provider(env)
+    if not provider:
+        raise ValueError("PHENOML_FHIR_PROVIDER_ID is required in mopa-lang2fhir/.env")
+
+    response = as_dict(client.fhir.execute_bundle(fhir_provider_id=provider, request=bundle))
+    locations = []
+    patient_id = None
+    for entry in response.get("entry", []) or []:
+        loc = (entry.get("response") or {}).get("location") or ""
+        if loc:
+            locations.append(loc)
+        if "Patient/" in loc and patient_id is None:
+            patient_id = loc.split("Patient/")[1].split("/")[0]
+    return {
+        "provider": provider,
+        "locations": locations,
+        "patient_id": patient_id,
+        "response": response,
+    }

--- a/mopa-lang2fhir/profiles.py
+++ b/mopa-lang2fhir/profiles.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Local OncoHealth profile registry and optional Lang2FHIR upload."""
+from pathlib import Path
+import json
+
+from common import HERE, as_dict, read_json
+
+PROFILE_DIR = HERE / "profiles"
+
+
+def list_profiles() -> list[dict]:
+    profiles = []
+    for path in sorted(PROFILE_DIR.glob("*.json")):
+        try:
+            data = read_json(path)
+            ok = data.get("resourceType") == "StructureDefinition"
+            profiles.append({
+                "file": path.name,
+                "id": data.get("id"),
+                "url": data.get("url"),
+                "name": data.get("name"),
+                "type": data.get("type"),
+                "valid": ok,
+                "error": None if ok else "resourceType must be StructureDefinition",
+            })
+        except Exception as exc:
+            profiles.append({
+                "file": path.name,
+                "id": None,
+                "url": None,
+                "name": None,
+                "type": None,
+                "valid": False,
+                "error": f"{type(exc).__name__}: {str(exc)[:180]}",
+            })
+    return profiles
+
+
+def upload_profiles(client) -> dict:
+    upload = getattr(getattr(client, "lang2fhir", None), "upload_profile", None)
+    if not callable(upload):
+        return {
+            "ok": False,
+            "message": "client.lang2fhir.upload_profile is not available in this SDK",
+            "results": [],
+        }
+
+    results = []
+    for path in sorted(PROFILE_DIR.glob("*.json")):
+        try:
+            profile = read_json(path)
+            if profile.get("resourceType") != "StructureDefinition":
+                raise ValueError("resourceType must be StructureDefinition")
+            try:
+                resp = upload(profile=json.dumps(profile))
+            except TypeError:
+                resp = upload(json.dumps(profile))
+            results.append({"file": path.name, "ok": True, "response": as_dict(resp)})
+        except Exception as exc:
+            results.append({"file": path.name, "ok": False,
+                            "error": f"{type(exc).__name__}: {str(exc)[:300]}"})
+
+    return {
+        "ok": bool(results) and all(item["ok"] for item in results),
+        "message": "upload attempted",
+        "results": results,
+    }

--- a/mopa-lang2fhir/profiles/oncohealth-oncology-evidence-observation.json
+++ b/mopa-lang2fhir/profiles/oncohealth-oncology-evidence-observation.json
@@ -1,0 +1,66 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "oncohealth-oncology-evidence-observation",
+  "url": "https://pheno.ml/demo/oncohealth/StructureDefinition/oncohealth-oncology-evidence-observation",
+  "version": "0.1.0",
+  "name": "OncoHealthOncologyEvidenceObservation",
+  "title": "OncoHealth Oncology Evidence Observation",
+  "status": "draft",
+  "experimental": true,
+  "date": "2026-07-06",
+  "publisher": "PhenoML demo",
+  "description": "Observation profile used by the demo to represent breast oncology evidence required by OncoHealth policy review, including ER, PR, HER2, stage group, and ECOG.",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.status",
+        "path": "Observation.status",
+        "min": 1
+      },
+      {
+        "id": "Observation.subject",
+        "path": "Observation.subject",
+        "min": 1,
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Patient"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Observation.code",
+        "path": "Observation.code",
+        "min": 1,
+        "binding": {
+          "strength": "extensible",
+          "description": "ER, PR, HER2, stage group, or ECOG performance status."
+        }
+      },
+      {
+        "id": "Observation.value[x]",
+        "path": "Observation.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "CodeableConcept"
+          },
+          {
+            "code": "string"
+          },
+          {
+            "code": "Quantity"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/mopa-lang2fhir/profiles/oncohealth-regimen-requestgroup.json
+++ b/mopa-lang2fhir/profiles/oncohealth-regimen-requestgroup.json
@@ -1,0 +1,64 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "oncohealth-regimen-requestgroup",
+  "url": "https://pheno.ml/demo/oncohealth/StructureDefinition/oncohealth-regimen-requestgroup",
+  "version": "0.1.0",
+  "name": "OncoHealthRegimenRequestGroup",
+  "title": "OncoHealth Regimen RequestGroup",
+  "status": "draft",
+  "experimental": true,
+  "date": "2026-07-06",
+  "publisher": "PhenoML demo",
+  "description": "RequestGroup profile used by the demo to hold an oncology regimen as the authorization unit, including component MedicationRequests and treatment context extensions.",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "RequestGroup",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/RequestGroup",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "RequestGroup.status",
+        "path": "RequestGroup.status",
+        "min": 1
+      },
+      {
+        "id": "RequestGroup.intent",
+        "path": "RequestGroup.intent",
+        "min": 1
+      },
+      {
+        "id": "RequestGroup.subject",
+        "path": "RequestGroup.subject",
+        "min": 1,
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Patient"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "RequestGroup.action",
+        "path": "RequestGroup.action",
+        "min": 1
+      },
+      {
+        "id": "RequestGroup.action.resource",
+        "path": "RequestGroup.action.resource",
+        "min": 1,
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/mopa-lang2fhir/profiles/oncohealth-summary-package.json
+++ b/mopa-lang2fhir/profiles/oncohealth-summary-package.json
@@ -1,0 +1,39 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "oncohealth-summary-package",
+  "url": "https://pheno.ml/demo/oncohealth/StructureDefinition/oncohealth-summary-package",
+  "version": "0.1.0",
+  "name": "OncoHealthSummaryPackage",
+  "title": "OncoHealth Summary Package Bundle",
+  "status": "draft",
+  "experimental": true,
+  "date": "2026-07-06",
+  "publisher": "PhenoML demo",
+  "description": "Bundle profile used by the demo for the resource collection passed to FHIR2Summary IPS mode.",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Bundle",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Bundle",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Bundle.type",
+        "path": "Bundle.type",
+        "min": 1,
+        "fixedCode": "collection"
+      },
+      {
+        "id": "Bundle.entry",
+        "path": "Bundle.entry",
+        "min": 1
+      },
+      {
+        "id": "Bundle.entry.resource",
+        "path": "Bundle.entry.resource",
+        "min": 1
+      }
+    ]
+  }
+}

--- a/mopa-lang2fhir/requirements.txt
+++ b/mopa-lang2fhir/requirements.txt
@@ -1,0 +1,5 @@
+phenoml>=15
+python-dotenv
+httpx
+fastapi
+uvicorn

--- a/mopa-lang2fhir/ui/index.html
+++ b/mopa-lang2fhir/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MOPA Lang2FHIR</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/mopa-lang2fhir/ui/package-lock.json
+++ b/mopa-lang2fhir/ui/package-lock.json
@@ -1,0 +1,2239 @@
+{
+  "name": "mopa-lang2fhir-ui",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mopa-lang2fhir-ui",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mantine/core": "^8.2.4",
+        "@mantine/hooks": "^8.2.4",
+        "@tabler/icons-react": "^3.34.1",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "@vitejs/plugin-react": "5.0.0",
+        "typescript": "^5.6.0",
+        "vite": "^7.3.6"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mantine/core": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.18.tgz",
+      "integrity": "sha512-9tph1lTVogKPjTx02eUxDUOdXacPzK62UuSqb4TdGliI54/Xgxftq0Dfqu6XuhCxn9J5MDJaNiLDvL/1KRkYqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "clsx": "^2.1.1",
+        "react-number-format": "^5.4.4",
+        "react-remove-scroll": "^2.7.1",
+        "react-textarea-autosize": "8.5.9",
+        "type-fest": "^4.41.0"
+      },
+      "peerDependencies": {
+        "@mantine/hooks": "8.3.18",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/hooks": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.18.tgz",
+      "integrity": "sha512-QoWr9+S8gg5050TQ06aTSxtlpGjYOpIllRbjYYXlRvZeTsUqiTbVfvQROLexu4rEaK+yy9Wwriwl9PMRgbLqPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.30.tgz",
+      "integrity": "sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
+      "integrity": "sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.44.0.tgz",
+      "integrity": "sha512-8+rvzBbVm/1Z3sG3x7GUNAaxIKxwgz8xaMhRs23nrCnMTKRFAhEC+82zAIFeAA0seXdrAGX5HFCkaLpGK2rVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": "3.44.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.0.tgz",
+      "integrity": "sha512-Jx9JfsTa05bYkS9xo0hkofp2dCmp1blrKjw9JONs5BTHOvJCgLbaPSuZLGSVJW6u2qe0tc4eevY0+gSNNi0YCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.30",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001802",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
+      "integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.387",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-number-format": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.5.tgz",
+      "integrity": "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/mopa-lang2fhir/ui/package.json
+++ b/mopa-lang2fhir/ui/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mopa-lang2fhir-ui",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Lang2FHIR and FHIR2Summary demo for MOPA breast oncology data",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1 --port 5174",
+    "build": "tsc && vite build",
+    "preview": "vite preview --host 127.0.0.1 --port 4174"
+  },
+  "dependencies": {
+    "@mantine/core": "^8.2.4",
+    "@mantine/hooks": "^8.2.4",
+    "@tabler/icons-react": "^3.34.1",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "5.0.0",
+    "typescript": "^5.6.0",
+    "vite": "^7.3.6"
+  }
+}

--- a/mopa-lang2fhir/ui/src/App.tsx
+++ b/mopa-lang2fhir/ui/src/App.tsx
@@ -1,0 +1,369 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  AppShell,
+  Badge,
+  Button,
+  Card,
+  Code,
+  Container,
+  Divider,
+  Grid,
+  Group,
+  Loader,
+  ScrollArea,
+  Stack,
+  Switch,
+  Table,
+  Text,
+  TextInput,
+  Textarea,
+  Title,
+} from "@mantine/core";
+import {
+  IconCloudUpload,
+  IconDatabaseExport,
+  IconFileAnalytics,
+  IconHeartbeat,
+  IconPackageExport,
+  IconRefresh,
+} from "@tabler/icons-react";
+import { api, type ExtractResult, type Health, type ProfileInfo, type SourceData } from "./api";
+
+const DEFAULT_HER2 =
+  "HER2 status by reflex in-situ hybridization (ISH): POSITIVE (HER2 gene amplified). " +
+  "Resolves the earlier equivocal IHC 2+ result.";
+
+function resourceLabel(resource: any): string {
+  return resource?.code?.text || resource?.code?.coding?.[0]?.display || resource?.resourceType || "";
+}
+
+function resourceValue(resource: any): string {
+  if (resource?.valueCodeableConcept?.text) return resource.valueCodeableConcept.text;
+  if (resource?.valueString) return resource.valueString;
+  if (resource?.valueQuantity) {
+    return `${resource.valueQuantity.value ?? ""} ${resource.valueQuantity.unit ?? ""}`.trim();
+  }
+  return "";
+}
+
+function JsonBlock({ value }: { value: any }) {
+  return (
+    <ScrollArea h={280} type="auto">
+      <Code block>{JSON.stringify(value, null, 2)}</Code>
+    </ScrollArea>
+  );
+}
+
+export function App() {
+  const [health, setHealth] = useState<Health | null>(null);
+  const [source, setSource] = useState<SourceData | null>(null);
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [report, setReport] = useState("");
+  const [includeHer2, setIncludeHer2] = useState(true);
+  const [her2Positive, setHer2Positive] = useState(true);
+  const [her2Text, setHer2Text] = useState(DEFAULT_HER2);
+  const [extractResult, setExtractResult] = useState<ExtractResult | null>(null);
+  const [summary, setSummary] = useState("");
+  const [writeResult, setWriteResult] = useState<any | null>(null);
+  const [uploadResult, setUploadResult] = useState<any | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  async function refresh() {
+    setError(null);
+    try {
+      const [h, s, p] = await Promise.all([api.health(), api.sourceData(), api.profiles()]);
+      setHealth(h);
+      setSource(s);
+      setProfiles(p.profiles);
+      setReport(s.report_text);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }
+
+  async function runExtract() {
+    setBusy("extract");
+    setError(null);
+    setSummary("");
+    setWriteResult(null);
+    setExtractResult(null);
+    try {
+      setExtractResult(await api.extract(report, includeHer2, her2Text, her2Positive));
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function runSummary() {
+    if (!extractResult) return;
+    setBusy("summary");
+    setError(null);
+    try {
+      const result = await api.summary(extractResult.extraction_id);
+      setSummary(result.summary);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function writeBundle() {
+    if (!extractResult) return;
+    setBusy("write");
+    setError(null);
+    setWriteResult(null);
+    try {
+      setWriteResult(await api.writeBundle(extractResult.extraction_id));
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function uploadProfiles() {
+    setBusy("profiles");
+    setError(null);
+    setUploadResult(null);
+    try {
+      setUploadResult(await api.uploadProfiles());
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const resourceCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const resource of extractResult?.resources || []) {
+      counts[resource.resourceType] = (counts[resource.resourceType] || 0) + 1;
+    }
+    return counts;
+  }, [extractResult]);
+
+  return (
+    <AppShell header={{ height: 62 }} padding="md">
+      <AppShell.Header>
+        <Group h="100%" px="md" justify="space-between">
+          <Group gap="sm">
+            <IconHeartbeat size={22} />
+            <div>
+              <Title order={4}>MOPA Lang2FHIR</Title>
+              <Text size="xs" c="dimmed">Breast oncology data selection, Bundle write, and FHIR2Summary</Text>
+            </div>
+          </Group>
+          <Group gap="xs">
+            {health?.configured
+              ? <Badge color="teal" variant="light">PhenoML connected</Badge>
+              : <Badge color="red" variant="light">not configured</Badge>}
+            {health?.fhir_provider_id
+              ? <Badge color="blue" variant="light">FHIR Provider {health.fhir_provider_id}</Badge>
+              : <Badge color="orange" variant="light">no FHIR Provider</Badge>}
+          </Group>
+        </Group>
+      </AppShell.Header>
+
+      <AppShell.Main>
+        <Container size="xl">
+          <Stack gap="md">
+            {error && <Alert color="red" title="Error">{error}</Alert>}
+
+            <Grid>
+              <Grid.Col span={{ base: 12, lg: 4 }}>
+                <Stack gap="md">
+                  <Card withBorder radius="sm" padding="md">
+                    <Group justify="space-between" mb="xs">
+                      <Text fw={600}>Source data</Text>
+                      <Button size="xs" variant="subtle" leftSection={<IconRefresh size={14} />} onClick={refresh}>
+                        Refresh
+                      </Button>
+                    </Group>
+                    <Table verticalSpacing={4}>
+                      <Table.Tbody>
+                        {(source?.artifacts || []).map((item) => (
+                          <Table.Tr key={item.name}>
+                            <Table.Td><Badge color={item.used ? "teal" : "gray"}>{item.used ? "used" : "not used"}</Badge></Table.Td>
+                            <Table.Td>
+                              <Text size="sm" fw={500}>{item.name}</Text>
+                              <Text size="xs" c="dimmed">{item.use}</Text>
+                            </Table.Td>
+                          </Table.Tr>
+                        ))}
+                      </Table.Tbody>
+                    </Table>
+                  </Card>
+
+                  <Card withBorder radius="sm" padding="md">
+                    <Text fw={600} mb="xs">OncoHealth data map</Text>
+                    <Table verticalSpacing={4}>
+                      <Table.Tbody>
+                        {(source?.mapped_requirements || []).map((item) => (
+                          <Table.Tr key={`${item.type}-${item.code || item.label}`}>
+                            <Table.Td><Badge variant="light">{item.type}</Badge></Table.Td>
+                            <Table.Td>
+                              <Text size="sm">{item.label}</Text>
+                              <Text size="xs" c="dimmed">{item.source}{item.code ? ` · ${item.code}` : ""}</Text>
+                            </Table.Td>
+                          </Table.Tr>
+                        ))}
+                      </Table.Tbody>
+                    </Table>
+                  </Card>
+
+                  <Card withBorder radius="sm" padding="md">
+                    <Group justify="space-between" mb="xs">
+                      <Text fw={600}>Profiles</Text>
+                      <Button
+                        size="xs"
+                        variant="light"
+                        leftSection={<IconCloudUpload size={14} />}
+                        loading={busy === "profiles"}
+                        onClick={uploadProfiles}
+                      >
+                        Upload
+                      </Button>
+                    </Group>
+                    <Stack gap={6}>
+                      {profiles.map((profile) => (
+                        <Group key={profile.file} justify="space-between" gap="xs">
+                          <Text size="sm">{profile.name || profile.file}</Text>
+                          <Badge color={profile.valid ? "teal" : "red"} variant="light">
+                            {profile.type || "invalid"}
+                          </Badge>
+                        </Group>
+                      ))}
+                    </Stack>
+                    {uploadResult && (
+                      <>
+                        <Divider my="sm" />
+                        <JsonBlock value={uploadResult} />
+                      </>
+                    )}
+                  </Card>
+                </Stack>
+              </Grid.Col>
+
+              <Grid.Col span={{ base: 12, lg: 8 }}>
+                <Stack gap="md">
+                  <Card withBorder radius="sm" padding="md">
+                    <Group justify="space-between" mb="xs">
+                      <Text fw={600}>Lang2FHIR input</Text>
+                      <Group gap="xs">
+                        <Switch
+                          checked={includeHer2}
+                          onChange={(event) => setIncludeHer2(event.currentTarget.checked)}
+                          label="Include resolved HER2"
+                        />
+                        <Switch
+                          checked={her2Positive}
+                          onChange={(event) => setHer2Positive(event.currentTarget.checked)}
+                          label={her2Positive ? "HER2 positive" : "HER2 negative"}
+                        />
+                      </Group>
+                    </Group>
+                    <Textarea value={report} onChange={(event) => setReport(event.currentTarget.value)} autosize minRows={6} maxRows={12} />
+                    {includeHer2 && (
+                      <TextInput mt="sm" value={her2Text} onChange={(event) => setHer2Text(event.currentTarget.value)} />
+                    )}
+                    <Group mt="sm">
+                      <Button leftSection={<IconPackageExport size={16} />} onClick={runExtract} loading={busy === "extract"}>
+                        Generate Bundle
+                      </Button>
+                      <Button
+                        variant="light"
+                        leftSection={<IconDatabaseExport size={16} />}
+                        disabled={!extractResult}
+                        onClick={writeBundle}
+                        loading={busy === "write"}
+                      >
+                        Write Bundle to FHIR Provider
+                      </Button>
+                      <Button
+                        variant="light"
+                        leftSection={<IconFileAnalytics size={16} />}
+                        disabled={!extractResult}
+                        onClick={runSummary}
+                        loading={busy === "summary"}
+                      >
+                        Run FHIR2Summary
+                      </Button>
+                    </Group>
+                  </Card>
+
+                  {busy && (
+                    <Group><Loader size="sm" /><Text size="sm">Working...</Text></Group>
+                  )}
+
+                  {extractResult && (
+                    <Grid>
+                      <Grid.Col span={{ base: 12, md: 6 }}>
+                        <Card withBorder radius="sm" padding="md">
+                          <Group justify="space-between" mb="xs">
+                            <Text fw={600}>Selected resources</Text>
+                            <Group gap={4}>
+                              {Object.entries(resourceCounts).map(([type, count]) => (
+                                <Badge key={type} variant="light">{type} {count}</Badge>
+                              ))}
+                            </Group>
+                          </Group>
+                          <Table verticalSpacing={4}>
+                            <Table.Tbody>
+                              {extractResult.resources.map((resource, index) => (
+                                <Table.Tr key={index}>
+                                  <Table.Td><Badge variant="light">{resource.resourceType}</Badge></Table.Td>
+                                  <Table.Td>
+                                    <Text size="sm">{resourceLabel(resource)}</Text>
+                                    <Text size="xs" c="dimmed">{resourceValue(resource)}</Text>
+                                  </Table.Td>
+                                </Table.Tr>
+                              ))}
+                            </Table.Tbody>
+                          </Table>
+                        </Card>
+                      </Grid.Col>
+                      <Grid.Col span={{ base: 12, md: 6 }}>
+                        <Card withBorder radius="sm" padding="md">
+                          <Text fw={600} mb="xs">Transaction Bundle</Text>
+                          <JsonBlock value={extractResult.bundle} />
+                        </Card>
+                      </Grid.Col>
+                    </Grid>
+                  )}
+
+                  {writeResult && (
+                    <Card withBorder radius="sm" padding="md">
+                      <Group justify="space-between" mb="xs">
+                        <Text fw={600}>FHIR Proxy write</Text>
+                        <Badge color="teal" variant="light">{writeResult.locations?.length || 0} resources</Badge>
+                      </Group>
+                      <Text size="sm">Provider: {writeResult.provider}</Text>
+                      {writeResult.patient_id && <Text size="sm">Patient/{writeResult.patient_id}</Text>}
+                      <JsonBlock value={writeResult.locations} />
+                    </Card>
+                  )}
+
+                  {summary && (
+                    <Card withBorder radius="sm" padding="md">
+                      <Text fw={600} mb="xs">FHIR2Summary IPS output</Text>
+                      <Text size="sm" style={{ whiteSpace: "pre-wrap" }}>{summary}</Text>
+                    </Card>
+                  )}
+                </Stack>
+              </Grid.Col>
+            </Grid>
+          </Stack>
+        </Container>
+      </AppShell.Main>
+    </AppShell>
+  );
+}

--- a/mopa-lang2fhir/ui/src/api.ts
+++ b/mopa-lang2fhir/ui/src/api.ts
@@ -1,0 +1,73 @@
+async function req<T>(path: string, method = "GET", body?: unknown): Promise<T> {
+  const res = await fetch(`/api${path}`, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error((data && (data.detail || data.message)) || `HTTP ${res.status}`);
+  return data as T;
+}
+
+export interface Health {
+  configured: boolean;
+  fhir_provider_id: string | null;
+  profile_upload_capable: boolean;
+}
+
+export interface SourceArtifact {
+  name: string;
+  use: string;
+  used: boolean;
+}
+
+export interface RequirementMap {
+  type: string;
+  label: string;
+  code: string | null;
+  source: string;
+  used: boolean;
+}
+
+export interface SourceData {
+  report_text: string;
+  artifacts: SourceArtifact[];
+  mapped_requirements: RequirementMap[];
+  requirements: any;
+  regimen_template: any;
+}
+
+export interface ExtractResult {
+  extraction_id: string;
+  resources: any[];
+  base_resources: any[];
+  bundle: any;
+  summary_bundle: any;
+  regimen: any;
+  source_map: RequirementMap[];
+}
+
+export interface ProfileInfo {
+  file: string;
+  id: string | null;
+  url: string | null;
+  name: string | null;
+  type: string | null;
+  valid: boolean;
+  error: string | null;
+}
+
+export const api = {
+  health: () => req<Health>("/health"),
+  sourceData: () => req<SourceData>("/source-data"),
+  extract: (report_text: string, include_her2: boolean, her2_result: string, her2_positive: boolean) =>
+    req<ExtractResult>("/extract", "POST", { report_text, include_her2, her2_result, her2_positive }),
+  summary: (extraction_id: string) =>
+    req<{ summary: string }>("/summary", "POST", { extraction_id }),
+  writeBundle: (extraction_id: string) =>
+    req<{ provider: string; locations: string[]; patient_id: string | null; response: any }>(
+      "/fhir/write", "POST", { extraction_id }),
+  profiles: () => req<{ profiles: ProfileInfo[] }>("/profiles"),
+  uploadProfiles: () =>
+    req<{ ok: boolean; message: string; results: any[] }>("/profiles/upload", "POST"),
+};

--- a/mopa-lang2fhir/ui/src/main.tsx
+++ b/mopa-lang2fhir/ui/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { MantineProvider } from "@mantine/core";
+import "@mantine/core/styles.css";
+import { App } from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <MantineProvider defaultColorScheme="light">
+      <App />
+    </MantineProvider>
+  </React.StrictMode>,
+);

--- a/mopa-lang2fhir/ui/tsconfig.json
+++ b/mopa-lang2fhir/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/mopa-lang2fhir/ui/vite.config.ts
+++ b/mopa-lang2fhir/ui/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+    port: 5174,
+    proxy: {
+      "/api": "http://127.0.0.1:8002",
+    },
+  },
+});

--- a/mopa-lang2fhir/ui_server.py
+++ b/mopa-lang2fhir/ui_server.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""FastAPI backend for the MOPA Lang2FHIR demo."""
+import uuid
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from common import configured_provider, load_env, make_client
+import pipeline
+import profiles
+
+EXTRACTIONS: dict[str, dict] = {}
+
+app = FastAPI(title="MOPA Lang2FHIR demo")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:5174",
+        "http://127.0.0.1:5174",
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class ExtractReq(BaseModel):
+    report_text: str
+    include_her2: bool = True
+    her2_result: str = pipeline.DEFAULT_HER2
+    her2_positive: bool = True
+
+
+class IdReq(BaseModel):
+    extraction_id: str
+
+
+def _client():
+    env = load_env()
+    try:
+        return make_client(env), env
+    except Exception as exc:
+        raise HTTPException(503, str(exc))
+
+
+@app.get("/api/health")
+def health():
+    env = load_env()
+    configured = bool(env.get("PHENOML_CLIENT_ID") and env.get("PHENOML_CLIENT_SECRET"))
+    capability = False
+    if configured:
+        try:
+            client = make_client(env)
+            capability = callable(getattr(getattr(client, "lang2fhir", None), "upload_profile", None))
+        except Exception:
+            capability = False
+    return {
+        "configured": configured,
+        "fhir_provider_id": configured_provider(env),
+        "profile_upload_capable": capability,
+    }
+
+
+@app.get("/api/source-data")
+def source_data():
+    return pipeline.source_data()
+
+
+@app.post("/api/extract")
+def extract(req: ExtractReq):
+    if not req.report_text.strip():
+        raise HTTPException(400, "report_text is required")
+    client, _env = _client()
+    try:
+        result = pipeline.extract(
+            client,
+            req.report_text,
+            include_her2=req.include_her2,
+            her2_result=req.her2_result,
+            her2_positive=req.her2_positive,
+        )
+    except Exception as exc:
+        raise HTTPException(500, f"{type(exc).__name__}: {str(exc)[:400]}")
+
+    extraction_id = uuid.uuid4().hex[:12]
+    EXTRACTIONS[extraction_id] = result
+    return {
+        "extraction_id": extraction_id,
+        "resources": result["resources"],
+        "base_resources": result["base_resources"],
+        "bundle": result["bundle"],
+        "summary_bundle": result["summary_bundle"],
+        "regimen": result["regimen"],
+        "source_map": result["source_map"],
+    }
+
+
+@app.post("/api/summary")
+def summary(req: IdReq):
+    client, _env = _client()
+    result = EXTRACTIONS.get(req.extraction_id)
+    if not result:
+        raise HTTPException(404, "unknown extraction_id; run extraction again")
+    try:
+        return pipeline.summarize(client, result["summary_bundle"])
+    except Exception as exc:
+        raise HTTPException(500, f"{type(exc).__name__}: {str(exc)[:400]}")
+
+
+@app.post("/api/fhir/write")
+def fhir_write(req: IdReq):
+    client, env = _client()
+    result = EXTRACTIONS.get(req.extraction_id)
+    if not result:
+        raise HTTPException(404, "unknown extraction_id; run extraction again")
+    if not configured_provider(env):
+        raise HTTPException(400, "PHENOML_FHIR_PROVIDER_ID is required in mopa-lang2fhir/.env")
+    try:
+        return pipeline.write_bundle(client, env, result["bundle"])
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+    except Exception as exc:
+        raise HTTPException(502, f"{type(exc).__name__}: {str(exc)[:400]}")
+
+
+@app.get("/api/profiles")
+def profile_list():
+    return {"profiles": profiles.list_profiles()}
+
+
+@app.post("/api/profiles/upload")
+def profile_upload():
+    client, _env = _client()
+    return profiles.upload_profiles(client)
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("ui_server:app", host="127.0.0.1", port=8002, reload=True)


### PR DESCRIPTION
Wraps the `mopa-breast-pa` pipeline in a two-persona web app: a **Provider** view (paste a pathology report → live lang2fhir/construe/IPS + readiness gap-check → resolve HER2 → submit a preauthorization **Claim**) and a **Payer** view (queue of Claims → OncoHealth UM-9 recommendation → human-in-the-loop Approve/Deny → **ClaimResponse** + Coverage, with a HER2 what-if toggle). Medplum is the EHR, reached through PhenoML, and prior auth is modeled the standard FHIR way (Claim/ClaimResponse).

To support the UI without duplicating logic, the intake/readiness code is extracted into a return-based `pipeline.py` that is now shared by the refactored step scripts (`step1_intake.py`, `step1_5_readiness.py`) and a new FastAPI backend (`ui_server.py`); the CLI demo behaves exactly as before. New `pa_fhir.py` handles Claim/ClaimResponse/Coverage persistence with a read-only fallback so the demo still runs on shared instances, and a Vite/React/Mantine frontend lives under `ui/`.

Verified offline: modules import cleanly, the backend boots and degrades gracefully without credentials, the DTR/Claim/ClaimResponse wiring passes a smoke test, and the frontend typechecks and builds. The live PhenoML→Medplum round-trip has not been run yet (no credentials in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## To Test

Setup (from ‎⁠mopa-breast-pa/⁠): ‎⁠cp .env.example .env⁠, then set ‎⁠PHENOML_CLIENT_ID⁠ / ‎⁠PHENOML_CLIENT_SECRET⁠ (required, or the backend 503s). Set a writable ‎⁠PHENOML_FHIR_PROVIDER_ID⁠ for a real Medplum write; leave blank to run read-only via local ‎⁠.state/claims.json⁠.

1. Start: run ‎⁠make dev⁠ (installs deps first run, starts backend :8001 + frontend :5173). Wait for ‎⁠[ui] agents ready⁠ in the console, then open http://localhost:5173.

2. Provider — intake: load the sample pathology report (sample_path_report.txt), run intake. Expect patient Jane Smith and readiness flags HER2 missing.

3. Provider — submit: accept the pre-filled HER2 positive result and submit. Readiness flips to satisfied; a Claim gets queued.

4. Payer — review: switch to Payer view, open the queued Claim, request the recommendation → APPROVED. Flip the HER2 what-if toggle to negative → DENIED; back to positive → APPROVED.

5. Payer — decide: click Approve → writes a ClaimResponse, queue row moves ‎⁠queued⁠ → ‎⁠approved⁠.

Pass: both servers up, HER2-missing caught then resolved, recommendation approves for HER2+ and denies for HER2−, and the decision updates the queue. This is a draft PR with no CI/tests, so this manual run is the verification.

## Prompt:
Lost the exact prompt, but it was something like "add a simple UI to the content of PR #12. Include a Make file to start backend and front end simultaneously, write data to Medplum through FHIR Proxy."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New FHIR Claim/ClaimResponse/Coverage writes and duplicated clinical pipeline logic increase demo surface area, though read-only fallback and idempotent submit guards limit production impact.
> 
> **Overview**
> Adds a **two-persona prior-auth web app** on top of the existing MOPA breast-cancer pipeline: providers run intake through submit (HER2 resolution + preauthorization **Claim**), and payers work a **Claim** queue with UM-9 recommendations, HER2 what-if, and human **Approve/Deny** (**ClaimResponse** / **Coverage**).
> 
> Intake and readiness logic moves into shared **`pipeline.py`**; **`step1_intake.py`** and **`step1_5_readiness.py`** call it so the CLI narrative stays the same. **`ui_server.py`** (FastAPI) exposes intake/submit/queue/recommendation/decision APIs and reuses **`cds_hooks_server/evaluate.py`**; **`pa_fhir.py`** persists FHIR resources via PhenoML with a **`.state/claims.json`** fallback when the EHR is read-only. A Vite/React/Mantine **`ui/`** and **`Makefile`** (`make dev` on :8001/:5173) wire up local dev.
> 
> Also introduces a separate **`mopa-lang2fhir`** demo (provider-side Lang2FHIR bundle + optional FHIR Proxy write + IPS summary, without payer/CDS Hooks), documented in the root **README**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb7eed1c0b46a581a65c3cc924d69fdb69be8109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->